### PR TITLE
Clear history before manual redirects.

### DIFF
--- a/src/client/history/history.js
+++ b/src/client/history/history.js
@@ -135,6 +135,17 @@ spf.history.replace = function(opt_url, opt_state, opt_doCallback,
 
 
 /**
+ * Remove the latest history state from the stack.
+ * NOTE: If this is called without a state having been pushed, it will result in
+ * a back action to the last page. Use with care.
+ */
+spf.history.removeCurrentEntry = function() {
+  spf.state.set('history-ignore-pop', true);
+  window.history.back();
+};
+
+
+/**
  * See {@link #add} or {@link #replace}.
  *
  * @param {boolean} replace Whether to replace the previous entry.
@@ -179,6 +190,11 @@ spf.history.push_ = function(replace, opt_url, opt_state, opt_doCallback) {
 spf.history.pop_ = function(evt) {
   var url = spf.history.getCurrentUrl_();
   spf.debug.info('history.pop ', 'url=', url, 'evt=', evt);
+  // Skip a pop event and reset flag if the ignore state is set.
+  if (spf.state.get('history-ignore-pop')) {
+    spf.state.set('history-ignore-pop', false);
+    return;
+  }
   // Avoid the initial event on first load for a state.
   if (evt.state) {
     var state = evt.state;

--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -769,7 +769,18 @@ spf.nav.redirect = function(url) {
   spf.debug.warn('redirecting (', 'url=', url, ')');
   spf.nav.cancel();
   spf.nav.cancelAllPrefetchesExcept();
-  window.location.href = url;
+  // If the url has already changed, clear its entry to prevent browser
+  // inconsistency with history management for 301 responses on reloads. Chrome
+  // will identify that the starting url was the same, and replace the current
+  // history state, whereas Firefox will set a new state with the post 301
+  // value.
+  if (window.location.href == url) {
+    spf.history.removeCurrentEntry();
+  }
+  // Delay the redirect until after the history state has had time to clear.
+  setTimeout(function() {
+    window.location.href = url;
+  }, 0);
 };
 
 


### PR DESCRIPTION
Clear out the latest history entry by setting a one time ignore flag and then triggering history.back(). The popstate will execute and then promptly be ignored, removing the history entry.

Triggering this on redirect requests (if the URL matches), will solve the back button issues in Firefox that have arisen from 30x responses which can't be handled by SPF (such as a 301 to HTTPS).
