### PR TITLE
Add missing response key migration for `html -> body`.

### DIFF
--- a/src/client/nav/response.js
+++ b/src/client/nav/response.js
@@ -184,7 +184,8 @@ spf.nav.response.process = function(url, response, opt_callback, opt_navigate,
   }
 
   // Update content (one task per fragment or three tasks if animated).
-  var fragments = response['html'] || {};
+  // TODO(nicksay): Remove "html" key.
+  var fragments = response['body'] || response['html'] || {};
   var numBeforeFragments = num;
   for (var id in fragments) {
     fn = spf.bind(function(id, html, timing) {


### PR DESCRIPTION
(This was missed in 5186b2b2a8e80cfc05d70420810f082e35442e0e.)

Add tests to ensure response processing for html applies to both the
new `body` field and the deprecated `html` field.

Progress on #24.
