### PR TITLE
Add experimental "unified extraction" for parsing scripts and styles.

### DIFF
--- a/src/client/nav/response_test.js
+++ b/src/client/nav/response_test.js
@@ -16,6 +16,7 @@ goog.require('spf.string');
 
 describe('spf.nav.response', function() {
 
+
   describe('parse', function() {
 
     var begin = '[\r\n';
@@ -394,39 +395,219 @@ describe('spf.nav.response', function() {
       expect(parseAsSingle).not.toThrow();  // The chunk is valid JSON.
     });
 
-    it('script strings', function() {
-      var htmlScriptsString = '<head>' +
+  });
+
+
+  describe('extract', function() {
+
+    it('parses external scripts', function() {
+      var string = '<head>' +
+        // HTML4 style.
         '<script src="foo.js" name="foo"></script>' +
-        '<script src="bar.js" name="bar" async></script>' +
-        '<script src="baz.js" name="baz"></script>' +
+        // HTML4 style with spaces.
+        '<script src = "foo.js" name = "foo"></script>' +
+        // HTML5 style.
+        '<script src=bar.js name=bar async></script>' +
+        // HTML5 style with spaces.
+        '<script src = bar.js name = bar async></script>' +
+        // Single quotes.
+        "<script src='baz.js' name='baz'></script>" +
+        // Single quotes with spaces.
+        "<script src = 'baz.js' name = 'baz'></script>" +
+        // HTML4 style with async attribute.
         '<script src="qux.js" name="qux" async="async"></script>' +
         '</head>';
-      var expectedResult = {
+      var expected = {
         scripts: [
           {url: 'foo.js', text: '', name: 'foo', async: false},
+          {url: 'foo.js', text: '', name: 'foo', async: false},
+          {url: 'bar.js', text: '', name: 'bar', async: true},
           {url: 'bar.js', text: '', name: 'bar', async: true},
           {url: 'baz.js', text: '', name: 'baz', async: false},
+          {url: 'baz.js', text: '', name: 'baz', async: false},
           {url: 'qux.js', text: '', name: 'qux', async: true}
-        ]
+        ],
+        html: '<head></head>'
       };
 
-      var result = spf.nav.response.parseScripts_(htmlScriptsString);
-      expect(result.scripts).toEqual(expectedResult.scripts);
-      expect(result.html).toBe('<head></head>');
+      var result = spf.nav.response.extract_(string);
+      expect(result.scripts).toEqual(expected.scripts);
+      expect(result.html).toEqual(expected.html);
     });
 
-    it('inline script strings', function() {
-      var htmlScriptsString = '<head>' +
+    it('parses inline scripts', function() {
+      var string = '<head>' +
         '<script name="quatre">window.foo = 4</script>' +
         '<script name="vingt">window.foo *= 20</script>' +
         '<script name="dix">window.foo += 10</script>' +
         '</head>';
+      var expected = {
+        scripts: [
+          {url: '', text: 'window.foo = 4', name: 'quatre', async: false},
+          {url: '', text: 'window.foo *= 20', name: 'vingt', async: false},
+          {url: '', text: 'window.foo += 10', name: 'dix', async: false}
+        ],
+        html: '<head></head>'
+      };
+      var result = spf.nav.response.extract_(string);
+      expect(result.scripts).toEqual(expected.scripts);
+      expect(result.html).toEqual(expected.html);
+    });
 
-      var result = spf.nav.response.parseScripts_(htmlScriptsString);
-      spf.nav.response.installScripts_(result, function() {
-        var ninety = window.foo;
-        expect(ninety).toBe(90);
-      });
+    it('parses external styles', function() {
+      var string = '<head>' +
+        // HTML4 style.
+        '<link rel="stylesheet" href="foo.css" name="foo">' +
+        // HTML4 style with spaces.
+        '<link rel="stylesheet" href = "foo.css" name = "foo">' +
+        // HTML5 style.
+        '<link rel="stylesheet" href=bar.css name=bar>' +
+        // HTML5 style with spaces.
+        '<link rel="stylesheet" href = bar.css name = bar>' +
+        // Single quotes.
+        "<link rel='stylesheet' href='baz.css' name='baz'>" +
+        // Single quotes with spaces.
+        "<link rel='stylesheet' href = 'baz.css' name = 'baz'>" +
+        // Non-matching HTML4 style.
+        '<link href="qux.css">' +
+        // Non-matching HTML5 style.
+        '<link rel=other href=qux.css>' +
+        '</head>';
+      var expected = {
+        styles: [
+          {url: 'foo.css', text: '', name: 'foo'},
+          {url: 'foo.css', text: '', name: 'foo'},
+          {url: 'bar.css', text: '', name: 'bar'},
+          {url: 'bar.css', text: '', name: 'bar'},
+          {url: 'baz.css', text: '', name: 'baz'},
+          {url: 'baz.css', text: '', name: 'baz'}
+        ],
+        html: '<head><link href="qux.css"><link rel=other href=qux.css></head>'
+      };
+
+      var result = spf.nav.response.extract_(string);
+      expect(result.styles).toEqual(expected.styles);
+      expect(result.html).toBe(expected.html);
+    });
+
+    it('parses inline styles', function() {
+      var string = '<head>' +
+        '<style name="quatre">.foo { color: red }</style>' +
+        '<style name="vingt">.foo { color: blue }</style>' +
+        '<style name="dix">.foo { color: green }</style>' +
+        '</head>';
+      var expected = {
+        styles: [
+          {url: '', text: '.foo { color: red }', name: 'quatre'},
+          {url: '', text: '.foo { color: blue }', name: 'vingt'},
+          {url: '', text: '.foo { color: green }', name: 'dix'}
+        ],
+        html: '<head></head>'
+      };
+
+      var result = spf.nav.response.extract_(string);
+      expect(result.styles).toEqual(expected.styles);
+      expect(result.html).toBe(expected.html);
+    });
+
+  });
+
+
+  describe('parseScripts', function() {
+
+    it('parses external scripts', function() {
+      var string = '<head>' +
+        // HTML4 style.
+        '<script src="foo.js" name="foo"></script>' +
+        // NOTE: HTML4 style with spaces not supported.
+        // NOTE: HTML5 style not supported.
+        // NOTE: HTML5 style with spaces not supported.
+        // NOTE: Single quotes not supported.
+        // NOTE: Single quotes with spaces not supported.
+        // HTML4 style with async attribute.
+        '<script src="qux.js" name="qux" async="async"></script>' +
+        '</head>';
+      var expected = {
+        scripts: [
+          {url: 'foo.js', text: '', name: 'foo', async: false},
+          {url: 'qux.js', text: '', name: 'qux', async: true}
+        ],
+        html: '<head></head>'
+      };
+
+      var result = spf.nav.response.parseScripts_(string);
+      expect(result.scripts).toEqual(expected.scripts);
+      expect(result.html).toEqual(expected.html);
+    });
+
+    it('parses inline scripts', function() {
+      var string = '<head>' +
+        '<script name="quatre">window.foo = 4</script>' +
+        '<script name="vingt">window.foo *= 20</script>' +
+        '<script name="dix">window.foo += 10</script>' +
+        '</head>';
+      var expected = {
+        scripts: [
+          {url: '', text: 'window.foo = 4', name: 'quatre', async: false},
+          {url: '', text: 'window.foo *= 20', name: 'vingt', async: false},
+          {url: '', text: 'window.foo += 10', name: 'dix', async: false}
+        ],
+        html: '<head></head>'
+      };
+      var result = spf.nav.response.parseScripts_(string);
+      expect(result.scripts).toEqual(expected.scripts);
+      expect(result.html).toEqual(expected.html);
+    });
+
+  });
+
+
+  describe('parseStyles', function() {
+
+    it('parses external styles', function() {
+      var string = '<head>' +
+        // HTML4 style.
+        '<link rel="stylesheet" href="foo.css" name="foo">' +
+        // NOTE: HTML4 style with spaces not supported.
+        // NOTE: HTML5 style not supported
+        // NOTE: Single quotes not supported.
+        // NOTE: Single quotes with spaces.
+        // Non-matching HTML4 style.
+        '<link href="qux.css">' +
+        // Non-matching HTML5 style.
+        '<link rel=other href=qux.css>' +
+        '</head>';
+      var expected = {
+        styles: [
+          {url: 'foo.css', text: '', name: 'foo'}
+        ],
+        html: '<head><link href="qux.css"><link rel=other href=qux.css></head>'
+      };
+
+      var result = spf.nav.response.parseStyles_(string);
+      expect(result.styles).toEqual(expected.styles);
+      expect(result.html).toBe(expected.html);
+    });
+
+    it('parses inline styles', function() {
+      // NOTE: name attributes not supported.
+      var string = '<head>' +
+        '<style>.foo { color: red }</style>' +
+        '<style>.foo { color: blue }</style>' +
+        '<style>.foo { color: green }</style>' +
+        '</head>';
+      var expected = {
+        styles: [
+          {url: '', text: '.foo { color: red }', name: ''},
+          {url: '', text: '.foo { color: blue }', name: ''},
+          {url: '', text: '.foo { color: green }', name: ''}
+        ],
+        html: '<head></head>'
+      };
+
+      var result = spf.nav.response.parseStyles_(string);
+      expect(result.styles).toEqual(expected.styles);
+      expect(result.html).toBe(expected.html);
     });
 
   });


### PR DESCRIPTION
Instead of having two methods for parsing scripts and styles, consolidate
them.  This also unifies the parse result object, which will allow
installation of scripts and styles from any fragment in the future.  For now,
guard the new method behind a `experimental-extract-unified` config.

Also, make the parsing logic much more robust, handling both HTML4 and HTML5
formats, as well as oddities like spaces and single quotes.  Add tests.

Progress on #24.
