### PR TITLE
Allow setting config values without defaults.

### DIFF
--- a/src/client/config.js
+++ b/src/client/config.js
@@ -15,8 +15,16 @@ goog.require('spf.state');
 
 
 /**
+ * Type definition for a SPF config value.
+ *
+ * @typedef {string|number|boolean|null}
+ */
+spf.config.Value;
+
+
+/**
  * Default configuration values.
- * @type {Object.<string, string|number|Function>}
+ * @type {!Object.<spf.config.Value>}
  */
 spf.config.defaults = {
   'animation-class': 'spf-animate',
@@ -36,14 +44,35 @@ spf.config.defaults = {
 
 
 /**
+ * Initialize the configuration with an optional object.  If values are not
+ * provided, the defaults are used if they exist.
+ *
+ * @param {Object.<spf.config.Value>=} opt_config Optional configuration object.
+ */
+spf.config.init = function(opt_config) {
+  var config = opt_config || {};
+  // Set primary configs; each has a default.
+  for (var key in spf.config.defaults) {
+    var value = (key in config) ? config[key] : spf.config.defaults[key];
+    spf.config.set(key, value);
+  }
+  // Set advanced and experimental configs; none have defaults.
+  for (var key in config) {
+    if (!(key in spf.config.defaults)) {
+      spf.config.set(key, config[key]);
+    }
+  }
+};
+
+
+/**
  * Checks whether a current configuration value exists.
  *
  * @param {string} name The configuration name.
  * @return {boolean} Whether the configuration value exists.
  */
 spf.config.has = function(name) {
-  var config = spf.config.config_();
-  return name in config;
+  return name in spf.config.values;
 };
 
 
@@ -51,11 +80,10 @@ spf.config.has = function(name) {
  * Gets a current configuration value.
  *
  * @param {string} name The configuration name.
- * @return {*} The configuration value.
+ * @return {spf.config.Value|undefined} The configuration value.
  */
 spf.config.get = function(name) {
-  var config = spf.config.config_();
-  return config[name];
+  return spf.config.values[name];
 };
 
 
@@ -63,12 +91,11 @@ spf.config.get = function(name) {
  * Sets a current configuration value.
  *
  * @param {string} name The configuration name.
- * @param {*} value The configuration value.
- * @return {*} The configuration value.
+ * @param {spf.config.Value} value The configuration value.
+ * @return {spf.config.Value} The configuration value.
  */
 spf.config.set = function(name, value) {
-  var config = spf.config.config_();
-  config[name] = value;
+  spf.config.values[name] = value;
   return value;
 };
 
@@ -77,21 +104,30 @@ spf.config.set = function(name, value) {
  * Removes all data from the config.
  */
 spf.config.clear = function() {
-  spf.config.config_({});
+  for (var key in spf.config.values) {
+    delete spf.config.values[key];
+  }
 };
 
 
 /**
- * @param {!Object.<string, *>=} opt_config Optional config
- *     object to overwrite the current value.
- * @return {!Object.<string, *>} Current config object.
- * @private
+ * The config storage object.
+ * @type {!Object.<spf.config.Value>}
  */
-spf.config.config_ = function(opt_config) {
-  if (opt_config || !spf.state.has('config')) {
-    return /** @type {!Object.<string, *>} */ (
-        spf.state.set('config', (opt_config || {})));
-  }
-  return /** @type {!Object.<string, *>} */ (
-      spf.state.get('config'));
-};
+spf.config.values = {};
+
+
+/**
+ * Key used to store and retrieve the config storage in state.
+ * @type {string}
+ * @const
+ */
+spf.config.VALUES_KEY = 'config';
+
+
+// Automatic initialization for spf.config.values.
+if (!spf.state.has(spf.config.VALUES_KEY)) {
+  spf.state.set(spf.config.VALUES_KEY, spf.config.values);
+}
+spf.config.values = /** @type {!Object.<spf.config.Value>} */ (
+    spf.state.get(spf.config.VALUES_KEY));

--- a/src/client/config_test.js
+++ b/src/client/config_test.js
@@ -1,0 +1,88 @@
+// Copyright 2014 Google Inc. All rights reserved.
+//
+// Use of this source code is governed by The MIT License.
+// See the LICENSE file for details.
+
+/**
+ * @fileoverview Tests for handling the SPF config.
+ */
+
+goog.require('spf.config');
+
+
+describe('spf.config', function() {
+
+  beforeEach(function() {
+    spf.config.defaults = {};
+    spf.config.values = {};
+  });
+
+
+  describe('has', function() {
+
+    it('checks values', function() {
+      spf.config.values['foo'] = 'foo';
+      expect(spf.config.has('foo')).toBe(true);
+      expect(spf.config.has('bar')).toBe(false);
+    });
+
+  });
+
+  describe('get', function() {
+
+    it('gets values', function() {
+      spf.config.values['foo'] = 'foo';
+      expect(spf.config.get('foo')).toBe('foo');
+      expect(spf.config.get('bar')).toBe(undefined);
+    })
+
+  });
+
+  describe('set', function() {
+
+    it('sets values', function() {
+      var v = spf.config.set('foo', 'foo');
+      expect(spf.config.values['foo']).toBe('foo');
+      expect(v).toBe('foo');
+      expect(spf.config.values['bar']).toBe(undefined)
+    })
+
+  });
+
+  describe('clear', function() {
+
+    it('clears values', function() {
+      spf.config.set('foo', 'foo');
+      expect(spf.config.has('foo')).toBe(true);
+      spf.config.clear();
+      expect(spf.config.has('foo')).toBe(false);
+    })
+
+  });
+
+  describe('init', function() {
+
+    it('uses defaults for values', function() {
+      spf.config.defaults['foo'] = 'foo';
+      spf.config.init();
+      expect(spf.config.get('foo')).toBe('foo');
+      expect(spf.config.get('bar')).toBe(undefined);
+    });
+
+    it('overrides defaults for values', function() {
+      spf.config.defaults['foo'] = 'foo';
+      spf.config.init({'foo': 'surprise!'});
+      expect(spf.config.get('foo')).toBe('surprise!');
+      expect(spf.config.get('bar')).toBe(undefined);
+    });
+
+    it('allows values without defaults', function() {
+      spf.config.defaults['foo'] = 'foo';
+      spf.config.init({'bar': 'bar'});
+      expect(spf.config.get('foo')).toBe('foo');
+      expect(spf.config.get('bar')).toBe('bar');
+    });
+
+  });
+
+});

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -31,11 +31,7 @@ goog.require('spf.pubsub');
 spf.main.init = function(opt_config) {
   var enable = spf.main.canInit_();
   spf.debug.info('main.init ', 'enable=', enable);
-  var config = opt_config || {};
-  for (var key in spf.config.defaults) {
-    var value = (key in config) ? config[key] : spf.config.defaults[key];
-    spf.config.set(key, value);
-  }
+  spf.config.init(opt_config);
   if (enable) {
     spf.nav.init();
   }

--- a/src/client/pubsub/pubsub.js
+++ b/src/client/pubsub/pubsub.js
@@ -132,7 +132,7 @@ if (SPF_BOOTLOADER) {
   spf.state.set(spf.pubsub.SUBS_KEY, spf.pubsub.subscriptions);
 } else {
   if (!spf.state.has(spf.pubsub.SUBS_KEY)) {
-    spf.state.set(spf.pubsub.SUBS_KEY, {});
+    spf.state.set(spf.pubsub.SUBS_KEY, spf.pubsub.subscriptions);
   }
   spf.pubsub.subscriptions = /** @type {!Object.<Array>} */ (
       spf.state.get(spf.pubsub.SUBS_KEY));


### PR DESCRIPTION
Move the config initialization code into the `spf.config` package and add tests.
