### PR TITLE
Add support for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+before_script:
+  - make
+script:
+  make tests

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,11 @@ tracing-bootloader:
 	@$(NINJA) tracing-bootloader
 tests:
 	@$(NINJA) tests
-	@if [[ $$(command -v open) ]]; then \
+	@if [[ $$(command -v phantomjs) ]]; then \
+			echo "Open build/test/runner.html in your browser for interactive testing."; \
+			echo "Running tests..."; \
+			phantomjs build/test/run-jasmine.js build/test/runner.html; \
+		elif [[ $$(command -v open) ]]; then \
 			echo "Opening build/test/runner.html in your browser..."; \
 			open build/test/runner.html; \
 		else \

--- a/NOTICE
+++ b/NOTICE
@@ -27,6 +27,12 @@ License: Apache 2
 Path: vendor/ninja
 Use: Build system
 
+PhantomJS
+URL: https://github.com/ariya/phantomjs
+License: BSD
+Path: vendor/phantomjs
+Use: JavaScript testing
+
 web.py
 URL: http://github.com/webpy/webpy
 License: Public Domain
@@ -605,6 +611,33 @@ Ninja
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+
+------------------------------------------------------------------------------
+PhantomJS
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the <organization> nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SPF
+# SPF  [![Build Status](https://secure.travis-ci.org/youtube/spfjs.png?branch=master)](http://travis-ci.org/youtube/spfjs)
 
 Structured Page Fragments — or SPF for short — is a lightweight framework that
 handles navigation and updates of page sections. Using progressive

--- a/configure.py
+++ b/configure.py
@@ -517,7 +517,9 @@ def write_targets(ninja):
   ]
   manifest_srcs = [dev_out] + js_tests
   manifest_out = '$builddir/test/manifest.js'
-  test_outs = jasmine_test_outs + [manifest_out]
+  phantomjs_run_jasmine_src = 'vendor/phantomjs/examples/run-jasmine.js'
+  phantomjs_run_jasmine_out = '$builddir/test/run-jasmine.js'
+  test_outs = jasmine_test_outs + [manifest_out, phantomjs_run_jasmine_out]
   runner_src = 'src/client/testing/runner.html'
   runner_out = '$builddir/test/runner.html'
   for test_src, test_out in zip(jasmine_test_srcs, jasmine_test_outs):
@@ -525,6 +527,9 @@ def write_targets(ninja):
                 variables=[('prefix', '../' * test_out.count('/'))])
   ninja.build(manifest_out, 'gen_test_manifest', manifest_srcs,
               variables=[('prefix', '../' * manifest_out.count('/'))])
+  ninja.build(phantomjs_run_jasmine_out, 'symlink', phantomjs_run_jasmine_src,
+              variables=[('prefix',
+                         '../' * phantomjs_run_jasmine_out.count('/'))])
   ninja.build(runner_out, 'symlink', runner_src,
               variables=[('prefix', '../' * runner_out.count('/'))],
               implicit=test_outs)

--- a/vendor/phantomjs/LICENSE.BSD
+++ b/vendor/phantomjs/LICENSE.BSD
@@ -1,0 +1,22 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the <organization> nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/phantomjs/examples/run-jasmine.js
+++ b/vendor/phantomjs/examples/run-jasmine.js
@@ -1,0 +1,86 @@
+var system = require('system');
+
+/**
+ * Wait until the test condition is true or a timeout occurs. Useful for waiting
+ * on a server response or for a ui change (fadeIn, etc.) to occur.
+ *
+ * @param testFx javascript condition that evaluates to a boolean,
+ * it can be passed in as a string (e.g.: "1 == 1" or "$('#bar').is(':visible')" or
+ * as a callback function.
+ * @param onReady what to do when testFx condition is fulfilled,
+ * it can be passed in as a string (e.g.: "1 == 1" or "$('#bar').is(':visible')" or
+ * as a callback function.
+ * @param timeOutMillis the max amount of time to wait. If not specified, 3 sec is used.
+ */
+function waitFor(testFx, onReady, timeOutMillis) {
+    var maxtimeOutMillis = timeOutMillis ? timeOutMillis : 3001, //< Default Max Timeout is 3s
+        start = new Date().getTime(),
+        condition = false,
+        interval = setInterval(function() {
+            if ( (new Date().getTime() - start < maxtimeOutMillis) && !condition ) {
+                // If not time-out yet and condition not yet fulfilled
+                condition = (typeof(testFx) === "string" ? eval(testFx) : testFx()); //< defensive code
+            } else {
+                if(!condition) {
+                    // If condition still not fulfilled (timeout but condition is 'false')
+                    console.log("'waitFor()' timeout");
+                    phantom.exit(1);
+                } else {
+                    // Condition fulfilled (timeout and/or condition is 'true')
+                    console.log("'waitFor()' finished in " + (new Date().getTime() - start) + "ms.");
+                    typeof(onReady) === "string" ? eval(onReady) : onReady(); //< Do what it's supposed to do once the condition is fulfilled
+                    clearInterval(interval); //< Stop this interval
+                }
+            }
+        }, 100); //< repeat check every 100ms
+};
+
+
+if (system.args.length !== 2) {
+    console.log('Usage: run-jasmine.js URL');
+    phantom.exit(1);
+}
+
+var page = require('webpage').create();
+
+// Route "console.log()" calls from within the Page context to the main Phantom context (i.e. current "this")
+page.onConsoleMessage = function(msg) {
+    console.log(msg);
+};
+
+page.open(system.args[1], function(status){
+    if (status !== "success") {
+        console.log("Unable to access network");
+        phantom.exit();
+    } else {
+        waitFor(function(){
+            return page.evaluate(function(){
+                return document.body.querySelector('.symbolSummary .pending') === null
+            });
+        }, function(){
+            var exitCode = page.evaluate(function(){
+                console.log('');
+                console.log(document.body.querySelector('.description').innerText);
+                var list = document.body.querySelectorAll('.results > #details > .specDetail.failed');
+                if (list && list.length > 0) {
+                  console.log('');
+                  console.log(list.length + ' test(s) FAILED:');
+                  for (i = 0; i < list.length; ++i) {
+                      var el = list[i],
+                          desc = el.querySelector('.description'),
+                          msg = el.querySelector('.resultMessage.fail');
+                      console.log('');
+                      console.log(desc.innerText);
+                      console.log(msg.innerText);
+                      console.log('');
+                  }
+                  return 1;
+                } else {
+                  console.log(document.body.querySelector('.alert > .passingAlert.bar').innerText);
+                  return 0;
+                }
+            });
+            phantom.exit(exitCode);
+        });
+    }
+});


### PR DESCRIPTION
This PR includes PhantomJS Jasmine runner to allow SPF tests to run from CLI where PhantomJS is available. It also add Travis-CI config file to support future integration of this GitHub repo with Travis-CI.
