### PR TITLE
Force execution of phantomjs on Travis-CI script as `make tests` can't find phantomjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "2.7"
 before_script:
   - make
+  - make tests
 script:
-  make tests
+  phantomjs build/test/run-jasmine.js build/test/runner.html


### PR DESCRIPTION
`command -v phantomjs` returns **not found** even though `phantomjs` is globally available in Travis-CI
