### PR TITLE
Refactor to unify spf.net.script and spf.net.style.

### DIFF
--- a/src/client/config_test.js
+++ b/src/client/config_test.js
@@ -34,7 +34,7 @@ describe('spf.config', function() {
       spf.config.values['foo'] = 'foo';
       expect(spf.config.get('foo')).toBe('foo');
       expect(spf.config.get('bar')).toBe(undefined);
-    })
+    });
 
   });
 
@@ -44,8 +44,8 @@ describe('spf.config', function() {
       var v = spf.config.set('foo', 'foo');
       expect(spf.config.values['foo']).toBe('foo');
       expect(v).toBe('foo');
-      expect(spf.config.values['bar']).toBe(undefined)
-    })
+      expect(spf.config.values['bar']).toBe(undefined);
+    });
 
   });
 
@@ -56,7 +56,7 @@ describe('spf.config', function() {
       expect(spf.config.has('foo')).toBe(true);
       spf.config.clear();
       expect(spf.config.has('foo')).toBe(false);
-    })
+    });
 
   });
 

--- a/src/client/dom/dom.js
+++ b/src/client/dom/dom.js
@@ -21,11 +21,13 @@ goog.require('spf');
  * return an empty Array.
  *
  * @param {string} selector Selector to match.
+ * @param {Document=} opt_document Optional document to query.
  * @return {Array.<Node>|NodeList} nodes Matching nodes.
  */
-spf.dom.query = function(selector) {
-  if (document.querySelectorAll) {
-    return document.querySelectorAll(selector);
+spf.dom.query = function(selector, opt_document) {
+  var doc = opt_document || document;
+  if (doc.querySelectorAll) {
+    return doc.querySelectorAll(selector);
   }
   return [];
 };

--- a/src/client/nav/response_test.js
+++ b/src/client/nav/response_test.js
@@ -643,7 +643,7 @@ describe('spf.nav.response', function() {
 
     afterEach(function() {
       elements = {};
-    })
+    });
 
     it('sets attributes from "attr" field', function() {
       elements = {
@@ -654,7 +654,7 @@ describe('spf.nav.response', function() {
       var response = {
         'attr': {
           'foo': { 'dir': 'rtl', 'class': 'last' },
-          'bar': { 'dir': 'rtl', 'class': 'last' },
+          'bar': { 'dir': 'rtl', 'class': 'last' }
         }
       };
 

--- a/src/client/net/resource_test.js
+++ b/src/client/net/resource_test.js
@@ -7,8 +7,9 @@
  * @fileoverview Tests for loading and unloading external resources.
  */
 
+goog.require('spf.array');
 goog.require('spf.net.resource');
-
+goog.require('spf.pubsub');
 goog.require('spf.url');
 
 
@@ -16,37 +17,484 @@ describe('spf.net.resource', function() {
 
   var js = spf.net.resource.Type.JS;
   var css = spf.net.resource.Type.CSS;
-  var fakes;
-
-  beforeEach(function() {
-    spf.state.values_ = {};
-    fakes = {
-      url: {
-        absolute: function(relative) {
-          if (relative.indexOf('//') > -1) {
-            return relative;
-          } else if (relative.indexOf('/') == 0) {
-            return '//test' + relative;
-          } else {
-            return '//test/' + relative;
-          }
+  var loading = spf.net.resource.Status.LOADING;
+  var loaded = spf.net.resource.Status.LOADED;
+  var nodes;
+  var callbacks;
+  var reals = {
+    resource: {
+      create: spf.net.resource.create,
+      destroy: spf.net.resource.destroy
+    }
+  };
+  var fakes = {
+    doc: {
+      createElement: function(tagName) {
+        return new FakeElement(tagName);
+      },
+      getElementsByTagName: function(tagName) {
+        tagName = tagName.toUpperCase();
+        return spf.array.filter(nodes, function(n) {
+          return n.tagName == tagName;
+        });
+      },
+      querySelectorAll: function(selector) {
+        // Only class matching is supported here.
+        var className = selector.substring(1);
+        return spf.array.filter(nodes, function(n) {
+          return n.className == className;
+        });
+      }
+    },
+    url: {
+      absolute: function(relative) {
+        if (relative.indexOf('//') > -1) {
+          return relative;
+        } else if (relative.indexOf('/') == 0) {
+          return '//test' + relative;
+        } else {
+          return '//test/' + relative;
         }
       }
+    },
+    resource: {
+      create: function(type, url, opt_callback) {
+        var el = reals.resource.create(type, url, opt_callback, fakes.doc);
+        setTimeout(el.onload, 0);
+        return el;
+      },
+      destroy: function(type, url) {
+        reals.resource.destroy(type, url, fakes.doc);
+      }
+    }
+  };
+
+  var FakeElement = function(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.attributes = {};
+    this.onload = function() {};
+    // Fake parentNode reference to allow "el.parentNode.removeChild" calls.
+    this.parentNode = this;
+  };
+  FakeElement.prototype.getAttribute = function(name) {
+    return this.attributes[name];
+  };
+  FakeElement.prototype.setAttribute = function(name, value) {
+    this.attributes[name] = value;
+  };
+  FakeElement.prototype.insertBefore = function(el, ref) {
+    nodes.unshift(el);
+  };
+  FakeElement.prototype.appendChild = function(el) {
+    nodes.push(el);
+  };
+  FakeElement.prototype.removeChild = function(el) {
+    var idx = -1;
+    spf.array.every(nodes, function(n, i, arr) {
+      if (n == el) {
+        idx = i;
+        return false;
+      }
+      return true;
+    });
+    nodes.splice(idx, 1);
+  };
+
+  var getScriptEls = function() {
+    return fakes.doc.getElementsByTagName('script');
+  };
+  var getScriptUrls = function() {
+    return spf.array.map(getScriptEls(), function(a) { return a.src; });
+  };
+  var getStyleEls = function() {
+    return fakes.doc.getElementsByTagName('link');
+  };
+  var getStyleUrls = function() {
+    return spf.array.map(getStyleEls(), function(a) { return a.href; });
+  };
+
+
+  beforeEach(function() {
+    jasmine.Clock.useMock();
+
+    spf.state.values_ = {};
+    spf.pubsub.subscriptions = {};
+    spf.net.resource.urls_ = {};
+    spf.net.resource.stats_ = {};
+
+    nodes = [new FakeElement('head')];
+    callbacks = {
+      one: jasmine.createSpy('one'),
+      two: jasmine.createSpy('two'),
+      three: jasmine.createSpy('three'),
+      four: jasmine.createSpy('four')
     };
+
     spyOn(spf.url, 'absolute').andCallFake(fakes.url.absolute);
+    spyOn(spf.net.resource, 'create').andCallFake(fakes.resource.create);
+    spyOn(spf.net.resource, 'destroy').andCallFake(fakes.resource.destroy);
   });
+
+
+  describe('load', function() {
+
+    it('a single url (script)', function() {
+      spf.net.resource.load(js, 'url-a.js');
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(1);
+      spf.net.resource.load(js, 'url-a.js');
+      jasmine.Clock.tick(1);
+      spf.net.resource.load(js, 'url-a.js');
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(1);
+      spf.net.resource.load(js, 'url-b.js');
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(2);
+    });
+
+    it('a single url (style)', function() {
+      spf.net.resource.load(css, 'url-a.css');
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(1);
+      spf.net.resource.load(css, 'url-a.css');
+      jasmine.Clock.tick(1);
+      spf.net.resource.load(css, 'url-a.css');
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(1);
+      spf.net.resource.load(css, 'url-b.css');
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(2);
+    });
+
+    it('a single url with a name (script)', function() {
+      spf.net.resource.load(js, 'url-a.js', 'a');
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(1);
+      spf.net.resource.load(js, 'url-a.js', 'a');
+      jasmine.Clock.tick(1);
+      spf.net.resource.load(js, 'url-a.js', 'a');
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(1);
+      spf.net.resource.load(js, 'url-b.js', 'b');
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(2);
+    });
+
+    it('a single url with a name (style)', function() {
+      spf.net.resource.load(css, 'url-a.css', 'a');
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(1);
+      spf.net.resource.load(css, 'url-a.css', 'a');
+      jasmine.Clock.tick(1);
+      spf.net.resource.load(css, 'url-a.css', 'a');
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(1);
+      spf.net.resource.load(css, 'url-b.css', 'b');
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(2);
+    });
+
+    it('multiple urls (script)', function() {
+      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js']);
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(2);
+      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js']);
+      jasmine.Clock.tick(1);
+      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js']);
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(2);
+      spf.net.resource.load(js, ['url-b-1.js', 'url-b-2.js']);
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(4);
+    });
+
+    it('multiple urls (style)', function() {
+      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css']);
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(2);
+      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css']);
+      jasmine.Clock.tick(1);
+      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css']);
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(2);
+      spf.net.resource.load(css, ['url-b-1.css', 'url-b-2.css']);
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(4);
+    });
+
+    it('multiple urls with a name (script)', function() {
+      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(2);
+      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
+      jasmine.Clock.tick(1);
+      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(2);
+      spf.net.resource.load(js, ['url-b-1.js', 'url-b-2.js'], 'b');
+      jasmine.Clock.tick(1);
+      expect(getScriptEls().length).toEqual(4);
+    });
+
+    it('multiple urls with a name (style)', function() {
+      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(2);
+      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
+      jasmine.Clock.tick(1);
+      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(2);
+      spf.net.resource.load(css, ['url-b-1.css', 'url-b-2.css'], 'b');
+      jasmine.Clock.tick(1);
+      expect(getStyleEls().length).toEqual(4);
+    });
+
+  });
+
+
+  describe('unload', function() {
+
+    it('a single url by name (script)', function() {
+      // Load a URL.
+      spf.net.resource.load(js, 'url-a.js', 'a');
+      jasmine.Clock.tick(1);
+      expect(getScriptUrls()).toContain('//test/url-a.js');
+      // Unload it.
+      spf.net.resource.unload(js, 'a');
+      expect('//test/url-a.js' in spf.net.resource.stats_).toBe(false);
+      expect(getScriptUrls()).not.toContain('//test/url-a.js');
+      // Repeated calls should be no-ops.
+      spf.net.resource.unload(js, 'a');
+      spf.net.resource.unload(js, 'a');
+      expect('//test/url-a.js' in spf.net.resource.stats_).toBe(false);
+      expect(getScriptUrls()).not.toContain('//test/url-a.js');
+    });
+
+    it('a single url by name (style)', function() {
+      // Load a URL.
+      spf.net.resource.load(css, 'url-a.css', 'a');
+      jasmine.Clock.tick(1);
+      expect(getStyleUrls()).toContain('//test/url-a.css');
+      // Unload it.
+      spf.net.resource.unload(css, 'a');
+      expect('//test/url-a.css' in spf.net.resource.stats_).toBe(false);
+      expect(getStyleUrls()).not.toContain('//test/url-a.css');
+      // Repeated calls should be no-ops.
+      spf.net.resource.unload(css, 'a');
+      spf.net.resource.unload(css, 'a');
+      expect('//test/url-a.css' in spf.net.resource.stats_).toBe(false);
+      expect(getStyleUrls()).not.toContain('//test/url-a.css');
+    });
+
+    it('multiple urls by name (script)', function() {
+      // Load some URLs (and check that they are "ready").
+      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
+      jasmine.Clock.tick(1);
+      expect(getScriptUrls()).toContain('//test/url-a-1.js');
+      expect(getScriptUrls()).toContain('//test/url-a-2.js');
+      // Remove them (and check that they are no longer "ready").
+      spf.net.resource.unload(js, 'a');
+      expect('//test/url-a-1.js' in spf.net.resource.stats_).toBe(false);
+      expect('//test/url-a-2.js' in spf.net.resource.stats_).toBe(false);
+      expect(getScriptUrls()).not.toContain('//test/url-a-1.js');
+      expect(getScriptUrls()).not.toContain('//test/url-a-2.js');
+      // Repeated calls should be no-ops.
+      spf.net.resource.unload(js, 'a');
+      spf.net.resource.unload(js, 'a');
+      expect('//test/url-a-1.js' in spf.net.resource.stats_).toBe(false);
+      expect('//test/url-a-2.js' in spf.net.resource.stats_).toBe(false);
+      expect(getScriptUrls()).not.toContain('//test/url-a-1.js');
+      expect(getScriptUrls()).not.toContain('//test/url-a-2.js');
+      // Check multiple names.
+      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
+      spf.net.resource.load(js, ['url-b-1.js', 'url-b-2.js'], 'b');
+      jasmine.Clock.tick(1);
+      expect(getScriptUrls()).toContain('//test/url-a-1.js');
+      expect(getScriptUrls()).toContain('//test/url-a-2.js');
+      expect(getScriptUrls()).toContain('//test/url-b-1.js');
+      expect(getScriptUrls()).toContain('//test/url-b-2.js');
+      spf.net.resource.unload(js, 'b');
+      expect(getScriptUrls()).toContain('//test/url-a-1.js');
+      expect(getScriptUrls()).toContain('//test/url-a-2.js');
+      expect(getScriptUrls()).not.toContain('//test/url-b-1.js');
+      expect(getScriptUrls()).not.toContain('//test/url-b-2.js');
+      spf.net.resource.unload(js, 'a');
+      expect(getScriptUrls()).not.toContain('//test/url-a-1.js');
+      expect(getScriptUrls()).not.toContain('//test/url-a-2.js');
+      expect(getScriptUrls()).not.toContain('//test/url-b-1.js');
+      expect(getScriptUrls()).not.toContain('//test/url-b-2.js');
+    });
+
+    it('multiple urls by name (style)', function() {
+      // Load some URLs (and check that they are "ready").
+      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
+      jasmine.Clock.tick(1);
+      expect(getStyleUrls()).toContain('//test/url-a-1.css');
+      expect(getStyleUrls()).toContain('//test/url-a-2.css');
+      // Remove them (and check that they are no longer "ready").
+      spf.net.resource.unload(css, 'a');
+      expect('//test/url-a-1.css' in spf.net.resource.stats_).toBe(false);
+      expect('//test/url-a-2.css' in spf.net.resource.stats_).toBe(false);
+      expect(getStyleUrls()).not.toContain('//test/url-a-1.css');
+      expect(getStyleUrls()).not.toContain('//test/url-a-2.css');
+      // Repeated calls should be no-ops.
+      spf.net.resource.unload(css, 'a');
+      spf.net.resource.unload(css, 'a');
+      expect('//test/url-a-1.css' in spf.net.resource.stats_).toBe(false);
+      expect('//test/url-a-2.css' in spf.net.resource.stats_).toBe(false);
+      expect(getStyleUrls()).not.toContain('//test/url-a-1.css');
+      expect(getStyleUrls()).not.toContain('//test/url-a-2.css');
+      // Check multiple names.
+      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
+      spf.net.resource.load(css, ['url-b-1.css', 'url-b-2.css'], 'b');
+      jasmine.Clock.tick(1);
+      expect(getStyleUrls()).toContain('//test/url-a-1.css');
+      expect(getStyleUrls()).toContain('//test/url-a-2.css');
+      expect(getStyleUrls()).toContain('//test/url-b-1.css');
+      expect(getStyleUrls()).toContain('//test/url-b-2.css');
+      spf.net.resource.unload(css, 'b');
+      expect(getStyleUrls()).toContain('//test/url-a-1.css');
+      expect(getStyleUrls()).toContain('//test/url-a-2.css');
+      expect(getStyleUrls()).not.toContain('//test/url-b-1.css');
+      expect(getStyleUrls()).not.toContain('//test/url-b-2.css');
+      spf.net.resource.unload(css, 'a');
+      expect(getStyleUrls()).not.toContain('//test/url-a-1.css');
+      expect(getStyleUrls()).not.toContain('//test/url-a-2.css');
+      expect(getStyleUrls()).not.toContain('//test/url-b-1.css');
+      expect(getStyleUrls()).not.toContain('//test/url-b-2.css');
+    });
+
+  });
+
+
+  describe('check', function() {
+
+    it('executes pending callbacks (script)', function() {
+      // No dependencies.
+      spf.pubsub.subscribe('js-foo', callbacks.one);
+      spf.pubsub.subscribe('js-bar', callbacks.two);
+      spf.pubsub.subscribe('js-foo|bar', callbacks.three);
+      spf.pubsub.subscribe('js-other', callbacks.four);
+      spf.net.resource.check(js);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(0);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // Not loaded.
+      spf.net.resource.urls_['js-foo'] = ['//test/f1.js', '//test/f2.js'];
+      spf.net.resource.urls_['js-bar'] = ['//test/b.js'];
+      spf.net.resource.check(js);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(0);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // Some loading.
+      spf.net.resource.stats_['//test/b.js'] = loading;
+      spf.net.resource.check(js);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(0);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // All loading.
+      spf.net.resource.stats_['//test/b.js'] = loading;
+      spf.net.resource.stats_['//test/f1.js'] = loading;
+      spf.net.resource.stats_['//test/f2.js'] = loading;
+      spf.net.resource.check(js);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(0);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // Some loaded, some loading.
+      spf.net.resource.stats_['//test/b.js'] = loaded;
+      spf.net.resource.stats_['//test/f1.js'] = loading;
+      spf.net.resource.stats_['//test/f2.js'] = loaded;
+      spf.net.resource.check(js);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(1);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // All loaded.
+      spf.net.resource.stats_['//test/b.js'] = loaded;
+      spf.net.resource.stats_['//test/f1.js'] = loaded;
+      spf.net.resource.stats_['//test/f2.js'] = loaded;
+      spf.net.resource.check(js);
+      expect(callbacks.one.calls.length).toEqual(1);
+      expect(callbacks.two.calls.length).toEqual(1);
+      expect(callbacks.three.calls.length).toEqual(1);
+      expect(callbacks.four.calls.length).toEqual(0);
+    });
+
+    it('executes pending callbacks (style)', function() {
+      // No dependencies.
+      spf.pubsub.subscribe('css-foo', callbacks.one);
+      spf.pubsub.subscribe('css-bar', callbacks.two);
+      spf.pubsub.subscribe('css-foo|bar', callbacks.three);
+      spf.pubsub.subscribe('css-other', callbacks.four);
+      spf.net.resource.check(css);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(0);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // Not loaded.
+      spf.net.resource.urls_['css-foo'] = ['//test/f1.css', '//test/f2.css'];
+      spf.net.resource.urls_['css-bar'] = ['//test/b.css'];
+      spf.net.resource.check(css);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(0);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // Some loading.
+      spf.net.resource.stats_['//test/b.css'] = loading;
+      spf.net.resource.check(css);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(0);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // All loading.
+      spf.net.resource.stats_['//test/b.css'] = loading;
+      spf.net.resource.stats_['//test/f1.css'] = loading;
+      spf.net.resource.stats_['//test/f2.css'] = loading;
+      spf.net.resource.check(css);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(0);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // Some loaded, some loading.
+      spf.net.resource.stats_['//test/b.css'] = loaded;
+      spf.net.resource.stats_['//test/f1.css'] = loading;
+      spf.net.resource.stats_['//test/f2.css'] = loaded;
+      spf.net.resource.check(css);
+      expect(callbacks.one.calls.length).toEqual(0);
+      expect(callbacks.two.calls.length).toEqual(1);
+      expect(callbacks.three.calls.length).toEqual(0);
+      expect(callbacks.four.calls.length).toEqual(0);
+      // All loaded.
+      spf.net.resource.stats_['//test/b.css'] = loaded;
+      spf.net.resource.stats_['//test/f1.css'] = loaded;
+      spf.net.resource.stats_['//test/f2.css'] = loaded;
+      spf.net.resource.check(css);
+      expect(callbacks.one.calls.length).toEqual(1);
+      expect(callbacks.two.calls.length).toEqual(1);
+      expect(callbacks.three.calls.length).toEqual(1);
+      expect(callbacks.four.calls.length).toEqual(0);
+    });
+
+  });
+
 
   describe('prefix', function() {
 
-    it('script: adds prefixes', function() {
+    it('adds prefixes (script)', function() {
       expect(spf.net.resource.prefix(js, 'foo')).toEqual('js-foo');
     });
 
-    it('style: adds prefixes', function() {
+    it('adds prefixes (sytle)', function() {
       expect(spf.net.resource.prefix(css, 'foo')).toEqual('css-foo');
     });
 
   });
+
 
   describe('label', function() {
 
@@ -63,9 +511,10 @@ describe('spf.net.resource', function() {
 
   });
 
+
   describe('canonicalize', function() {
 
-    it('files: script', function() {
+    it('files (script)', function() {
       var canonical = spf.net.resource.canonicalize(js, 'foo');
       expect(canonical).toEqual('//test/foo.js');
       canonical = spf.net.resource.canonicalize(js, 'foo.js');
@@ -93,7 +542,7 @@ describe('spf.net.resource', function() {
       expect(canonical).toEqual('//test/path/bar.js.extra');
     });
 
-    it('files: style', function() {
+    it('files (style)', function() {
       var canonical = spf.net.resource.canonicalize(css, 'foo');
       expect(canonical).toEqual('//test/foo.css');
       canonical = spf.net.resource.canonicalize(css, 'foo.css');
@@ -121,7 +570,7 @@ describe('spf.net.resource', function() {
       expect(canonical).toEqual('//test/path/bar.css.extra');
     });
 
-    it('relative paths: script', function() {
+    it('relative paths (script)', function() {
       var canonical = spf.net.resource.canonicalize(js, 'path/foo');
       expect(canonical).toEqual('//test/path/foo.js');
       canonical = spf.net.resource.canonicalize(js, 'path/foo.js');
@@ -149,7 +598,7 @@ describe('spf.net.resource', function() {
       expect(canonical).toEqual('//test/longpath/bar.js.extra');
     });
 
-    it('relative paths: style', function() {
+    it('relative paths (style)', function() {
       var canonical = spf.net.resource.canonicalize(css, 'path/foo');
       expect(canonical).toEqual('//test/path/foo.css');
       canonical = spf.net.resource.canonicalize(css, 'path/foo.css');
@@ -177,7 +626,7 @@ describe('spf.net.resource', function() {
       expect(canonical).toEqual('//test/longpath/bar.css.extra');
     });
 
-    it('absolute paths: script', function() {
+    it('absolute paths (script)', function() {
       var canonical = spf.net.resource.canonicalize(js, '/path/foo');
       expect(canonical).toEqual('//test/path/foo.js');
       canonical = spf.net.resource.canonicalize(js, '/path/foo.js');
@@ -205,7 +654,7 @@ describe('spf.net.resource', function() {
       expect(canonical).toEqual('http://domain/fullpath/bar.js.extra');
     });
 
-    it('absolute paths: style', function() {
+    it('absolute paths (style)', function() {
       var canonical = spf.net.resource.canonicalize(css, '/path/foo');
       expect(canonical).toEqual('//test/path/foo.css');
       canonical = spf.net.resource.canonicalize(css, '/path/foo.css');
@@ -233,7 +682,7 @@ describe('spf.net.resource', function() {
       expect(canonical).toEqual('http://domain/fullpath/bar.css.extra');
     });
 
-    it('urls: script', function() {
+    it('urls (script)', function() {
       var unprotocol = '//domain/path/bar.js';
       var http = 'http://domain/path/bar.js';
       var https = 'https://domain/path/bar.js';
@@ -271,7 +720,7 @@ describe('spf.net.resource', function() {
       expect(canonical).toEqual(local);
     });
 
-    it('urls: style', function() {
+    it('urls (style)', function() {
       var unprotocol = '//domain/path/bar.css';
       var http = 'http://domain/path/bar.css';
       var https = 'https://domain/path/bar.css';

--- a/src/client/net/style.js
+++ b/src/client/net/style.js
@@ -12,10 +12,7 @@
 goog.provide('spf.net.style');
 
 goog.require('spf.array');
-goog.require('spf.debug');
 goog.require('spf.net.resource');
-goog.require('spf.net.resource.urls');
-goog.require('spf.pubsub');
 goog.require('spf.string');
 goog.require('spf.tracing');
 
@@ -46,57 +43,7 @@ goog.require('spf.tracing');
  */
 spf.net.style.load = function(urls, opt_nameOrFn, opt_fn) {
   var type = spf.net.resource.Type.CSS;
-
-  // Convert to an array if needed.
-  urls = spf.array.toArray(urls);
-
-  // Determine if a name was provided with 2 or 3 arguments.
-  var withName = spf.string.isString(opt_nameOrFn);
-  var name = /** @type {string} */ (withName ? opt_nameOrFn : '');
-  var callback = /** @type {Function} */ (withName ? opt_fn : opt_nameOrFn);
-  spf.debug.debug('style.load', urls, name);
-
-  // After the styles are loaded, execute the callback by default.
-  var done = callback;
-
-  // If a name is provided with different URLs, then also unload the previous
-  // versions after the styles are loaded.
-  //
-  // NOTE: Unloading styles depends on onload support and is best effort.
-  // Chrome 19, Safari 6, Firefox 9, Opera and IE 5.5 support stylesheet onload.
-  if (name) {
-    var loaded = spf.array.every(urls, spf.net.style.loaded_);
-    var previous = spf.net.resource.urls.get(type, name);
-    // If loading new styles for a name, handle unloading previous ones.
-    if (!loaded && previous) {
-      spf.dispatch('cssbeforeunload', {'name': name, 'urls': previous});
-      spf.net.resource.urls.clear(type, name);
-      done = function() {
-        spf.net.style.unload_(name, previous);
-        callback && callback();
-      };
-    }
-  }
-
-  var pseudonym = name || '^' + urls.sort().join('^');
-  // Associate the styles with the name (or pseudonym) to allow unloading.
-  spf.net.resource.urls.set(type, pseudonym, urls);
-  // Subscribe the callback to execute when all urls are loaded.
-  var topic = spf.net.style.prefix_(pseudonym);
-  spf.debug.debug('  subscribing', topic, done);
-  spf.pubsub.subscribe(topic, done);
-  // Start asynchronously loading all the styles.
-  spf.array.each(urls, function(url) {
-    // If a status exists, the style is already loading or loaded.
-    if (spf.net.style.exists_(url)) {
-      spf.net.style.check();
-    } else {
-      var el = spf.net.style.get(url, spf.net.style.check);
-      if (name) {
-        el.setAttribute('name', name);
-      }
-    }
-  });
+  spf.net.resource.load(type, urls, opt_nameOrFn, opt_fn);
 };
 
 
@@ -106,47 +53,17 @@ spf.net.style.load = function(urls, opt_nameOrFn, opt_fn) {
  * @param {string} name The dependency name.
  */
 spf.net.style.unload = function(name) {
-  spf.debug.warn('style.unload', name);
   var type = spf.net.resource.Type.CSS;
-  // Convert to an array if needed.
-  var urls = spf.net.resource.urls.get(type, name) || [];
-  spf.net.resource.urls.clear(type, name);
-  spf.net.style.unload_(name, urls);
+  spf.net.resource.unload(type, name);
 };
 
-
-/**
- * See {@link unload}.
- *
- * @param {string} name The name.
- * @param {Array.<string>} urls The URLs.
- * @private
- */
-spf.net.style.unload_ = function(name, urls) {
-  var type = spf.net.resource.Type.CSS;
-  if (urls.length) {
-    spf.debug.debug('  > style.unload', urls);
-    spf.dispatch('cssunload', {'name': name, 'urls': urls});
-    spf.array.each(urls, function(url) {
-      spf.net.resource.destroy(type, url);
-    });
-  }
-};
 
 /**
  * Discovers existing styles in the document and registers them as loaded.
  */
 spf.net.style.discover = function() {
-  spf.debug.debug('style.discover');
   var type = spf.net.resource.Type.CSS;
-  var els = spf.net.resource.discover(type);
-  spf.array.each(els, function(el) {
-    var name = el.getAttribute('name');
-    if (name) {
-      spf.net.resource.urls.set(type, name, [el.href]);
-    }
-    spf.debug.debug('  found', el.href, name);
-  });
+  spf.net.resource.discover(type);
 };
 
 
@@ -161,39 +78,10 @@ spf.net.style.discover = function() {
  * @return {Element} The newly created element.
  */
 spf.net.style.get = function(url, opt_fn) {
-  var type = spf.net.resource.Type.CSS;
   // NOTE: Callback execution depends on onload support and is best effort.
   // Chrome 19, Safari 6, Firefox 9, Opera and IE 5.5 support stylesheet onload.
+  var type = spf.net.resource.Type.CSS;
   return spf.net.resource.create(type, url, opt_fn);
-};
-
-
-/**
- * Executes any pending callbacks possible by checking if all pending
- * urls for a name have loaded.
- */
-spf.net.style.check = function() {
-  spf.debug.debug('style.check');
-  var prefix = spf.net.style.prefix_('');
-  for (var topic in spf.pubsub.subscriptions) {
-    if (topic.indexOf(prefix) == 0) {
-      var names = topic.substring(prefix.length).split('|');
-      var ready = spf.array.every(names, spf.net.style.allLoaded_);
-      spf.debug.debug(' ', topic, '->', names, '=', ready);
-      if (ready) {
-        spf.debug.debug('  publishing', topic);
-        // Because check evaluates the pubsub.subscriptions array to determine
-        // if urls for names are loaded, there is a potential subscribe/publish
-        // infinite loop:
-        //     require_ -> load (subscribe) -> check (publish) ->
-        //     load (subscribe) -> <loop forever> ...
-        // To avoid this, use flush instead of publish + clear to ensure that
-        // previously subscribed functions are removed before execution:
-        //     require_ -> load (subscribe) -> check (flush) -> <no loop>
-        spf.pubsub.flush(topic);
-      }
-    }
-  }
 };
 
 
@@ -252,89 +140,21 @@ spf.net.style.path = function(paths) {
 };
 
 
-/**
- * Prefix a name to avoid conflicts.
- *
- * @param {?} name The name
- * @return {string} The prefixed name.
- * @private
- */
-spf.net.style.prefix_ = function(name) {
-  var type = spf.net.resource.Type.CSS;
-  return spf.net.resource.prefix(type, name);
-};
-
-
-/**
- * Checks to see if a style exists.
- * (If a URL is loading or loaded, then it exists.)
- *
- * @param {string} url The URL.
- * @return {boolean} Whether the URL is loaded.
- * @private
- */
-spf.net.style.exists_ = function(url) {
-  var type = spf.net.resource.Type.CSS;
-  return spf.net.resource.exists(type, url);
-};
-
-
-/**
- * Checks to see if a style has been loaded.
- * (Falsey URL values (e.g. null or an empty string) are always "loaded".)
- *
- * @param {string} url The URL.
- * @return {boolean} Whether the URL is loaded.
- * @private
- */
-spf.net.style.loaded_ = function(url) {
-  var type = spf.net.resource.Type.CSS;
-  return spf.net.resource.loaded(type, url);
-};
-
-
-/**
- * Checks to see if all urls for a dependency have been loaded.
- * (Falsey dependency names (e.g. null or an empty string) are always "loaded".)
- *
- * @param {string} name The dependency name.
- * @return {boolean}
- * @private
- */
-spf.net.style.allLoaded_ = function(name) {
-  var type = spf.net.resource.Type.CSS;
-  var urls = spf.net.resource.urls.get(type, name);
-  return !name || (!!urls && spf.array.every(urls, spf.net.style.loaded_));
-};
-
-
 if (spf.tracing.ENABLED) {
   (function() {
     spf.net.style.load = spf.tracing.instrument(
         spf.net.style.load, 'spf.net.style.load');
     spf.net.style.unload = spf.tracing.instrument(
         spf.net.style.unload, 'spf.net.style.unload');
-    spf.net.style.unload_ = spf.tracing.instrument(
-        spf.net.style.unload_, 'spf.net.style.unload_');
     spf.net.style.discover = spf.tracing.instrument(
         spf.net.style.discover, 'spf.net.style.discover');
     spf.net.style.get = spf.tracing.instrument(
         spf.net.style.get, 'spf.net.style.get');
-    spf.net.style.check = spf.tracing.instrument(
-        spf.net.style.check, 'spf.net.style.check');
     spf.net.style.prefetch = spf.tracing.instrument(
         spf.net.style.prefetch, 'spf.net.style.prefetch');
     spf.net.style.eval = spf.tracing.instrument(
         spf.net.style.eval, 'spf.net.style.eval');
     spf.net.style.path = spf.tracing.instrument(
         spf.net.style.path, 'spf.net.style.path');
-    spf.net.style.prefix_ = spf.tracing.instrument(
-        spf.net.style.prefix_, 'spf.net.style.prefix_');
-    spf.net.style.exists_ = spf.tracing.instrument(
-        spf.net.style.exists_, 'spf.net.style.exists_');
-    spf.net.style.loaded_ = spf.tracing.instrument(
-        spf.net.style.loaded_, 'spf.net.style.loaded_');
-    spf.net.style.allLoaded_ = spf.tracing.instrument(
-        spf.net.style.allLoaded_, 'spf.net.style.allLoaded_');
   })();
 }

--- a/src/client/net/style_test.js
+++ b/src/client/net/style_test.js
@@ -14,196 +14,135 @@ goog.require('spf.net.style');
 
 describe('spf.net.style', function() {
 
-  var fakes;
-  var nodes;
   var css = spf.net.resource.Type.CSS;
-  var loading = spf.net.resource.Status.LOADING;
-  var loaded = spf.net.resource.Status.LOADED;
 
   beforeEach(function() {
-    jasmine.Clock.useMock();
-    fakes = {
-      // Replace DOM-based functions with fakes.
-      url: {
-        absolute: function(relative) {
-          if (relative.indexOf('//') > -1) {
-            return relative;
-          } else if (relative.indexOf('/') == 0) {
-            return '//test' + relative;
-          } else {
-            return '//test/' + relative;
-          }
-        }
-      },
-      resource: {
-        create: function(type, url, opt_callback, opt_document) {
-          var el = {
-            setAttribute: function(n, v) {
-              el[n] = v;
-            },
-            getAttribute: function(n) {
-              return el[n];
-            }
-          };
-          url = spf.net.resource.canonicalize(css, url);
-          el.href = url;
-          el.className = type + '-' + url.replace(/[^\w]/g, '');
-          nodes.push(el);
-          spf.net.resource.stats_[url] = loaded;
-          opt_callback && opt_callback();
-          return el;
-        },
-        destroy: function(type, url) {
-          var idx = -1;
-          spf.array.every(nodes, function(n, i, arr) {
-            if (n.href == url) {
-              idx = i;
-              return false;
-            }
-            return true;
-          });
-          nodes.splice(idx, 1);
-          delete spf.net.resource.stats_[url];
-        }
-      }
-    };
-    spyOn(spf.url, 'absolute').andCallFake(fakes.url.absolute);
-    spyOn(spf.net.resource, 'create').andCallFake(
-        fakes.resource.create);
-    spyOn(spf.net.resource, 'destroy').andCallFake(
-        fakes.resource.destroy);
-    spf.state.values_ = {};
-    spf.net.resource.urls_ = {};
-    spf.net.resource.stats_ = {};
-    nodes = [];
+    spyOn(spf.net.resource, 'load');
+    spyOn(spf.net.resource, 'unload');
+    spyOn(spf.net.resource, 'create');
+    spyOn(spf.net.resource, 'prefetch');
   });
+
 
   describe('load', function() {
 
-    it('single url', function() {
-      spf.net.style.load('url-a.css');
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(1);
-      spf.net.style.load('url-a.css');
-      jasmine.Clock.tick(1);
-      spf.net.style.load('url-a.css');
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(1);
-      spf.net.style.load('url-b.css');
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(2);
+    it('passes a single url', function() {
+      var url = 'url-a.css';
+      spf.net.style.load(url);
+      expect(spf.net.resource.load).toHaveBeenCalledWith(
+          css, url, undefined, undefined);
     });
 
-    it('single url with name', function() {
-      spf.net.style.load('url-a.css', 'a');
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(1);
-      spf.net.style.load('url-a.css', 'a');
-      jasmine.Clock.tick(1);
-      spf.net.style.load('url-a.css', 'a');
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(1);
-      spf.net.style.load('url-b.css', 'b');
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(2);
+    it('passes a single url with name', function() {
+      var url = 'url-a.css';
+      var name = 'a';
+      spf.net.style.load(url, name);
+      expect(spf.net.resource.load).toHaveBeenCalledWith(
+          css, url, name, undefined);
     });
 
-    it('multiple urls', function() {
-      spf.net.style.load(['url-a-1.css', 'url-a-2.css']);
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(2);
-      spf.net.style.load(['url-a-1.css', 'url-a-2.css']);
-      jasmine.Clock.tick(1);
-      spf.net.style.load(['url-a-1.css', 'url-a-2.css']);
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(2);
-      spf.net.style.load(['url-b-1.css', 'url-b-2.css']);
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(4);
+    it('passes a single url with function', function() {
+      var url = 'url-a.css';
+      var fn = function() {};
+      spf.net.style.load(url, fn);
+      expect(spf.net.resource.load).toHaveBeenCalledWith(
+          css, url, fn, undefined);
     });
 
-    it('multiple urls with name', function() {
-      spf.net.style.load(['url-a-1.css', 'url-a-2.css'], 'a');
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(2);
-      spf.net.style.load(['url-a-1.css', 'url-a-2.css'], 'a');
-      jasmine.Clock.tick(1);
-      spf.net.style.load(['url-a-1.css', 'url-a-2.css'], 'a');
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(2);
-      spf.net.style.load(['url-b-1.css', 'url-b-2.css'], 'b');
-      jasmine.Clock.tick(1);
-      expect(nodes.length).toEqual(4);
+    it('passes a single url with name function', function() {
+      var url = 'url-a.css';
+      var name = 'a';
+      var fn = function() {};
+      spf.net.style.load(url, name, fn);
+      expect(spf.net.resource.load).toHaveBeenCalledWith(
+          css, url, name, fn);
+    });
+
+    it('passes multiple urls', function() {
+      var urls = ['url-a-1.css', 'url-a-2.css'];
+      spf.net.style.load(urls);
+      expect(spf.net.resource.load).toHaveBeenCalledWith(
+          css, urls, undefined, undefined);
+    });
+
+    it('passes multiple urls with name', function() {
+      var urls = ['url-a-1.css', 'url-a-2.css'];
+      var name = 'a';
+      spf.net.style.load(urls, name);
+      expect(spf.net.resource.load).toHaveBeenCalledWith(
+          css, urls, name, undefined);
+    });
+
+    it('passes multiple urls with function', function() {
+      var urls = ['url-a-1.css', 'url-a-2.css'];
+      var fn = function() {};
+      spf.net.style.load(urls, fn);
+      expect(spf.net.resource.load).toHaveBeenCalledWith(
+          css, urls, fn, undefined);
+    });
+
+    it('passes multiple urls with name function', function() {
+      var urls = ['url-a-1.css', 'url-a-2.css'];
+      var name = 'a';
+      var fn = function() {};
+      spf.net.style.load(urls, name, fn);
+      expect(spf.net.resource.load).toHaveBeenCalledWith(
+          css, urls, name, fn);
     });
 
   });
+
 
   describe('unload', function() {
 
-    it('single url by name', function() {
-      // Load a URL.
-      spf.net.style.load('url-a.css', 'a');
-      jasmine.Clock.tick(1);
-      var result = spf.array.map(nodes, function(a) { return a.href; });
-      expect(result).toContain('//test/url-a.css');
-      // Unload it.
-      spf.net.style.unload('a');
-      result = spf.array.map(nodes, function(a) { return a.href; });
-      expect('//test/url-a.css' in spf.net.resource.stats_).toBe(false);
-      expect(result).not.toContain('//test/url-a.css');
-      // Repeated calls should be no-ops.
-      spf.net.style.unload('a');
-      spf.net.style.unload('a');
-      result = spf.array.map(nodes, function(a) { return a.href; });
-      expect('//test/url-a.css' in spf.net.resource.stats_).toBe(false);
-      expect(result).not.toContain('//test/url-a.css');
-    });
-
-    it('multiple urls by name', function() {
-      // Load some URLs (and check that they are "ready").
-      spf.net.style.load(['url-a-1.css', 'url-a-2.css'], 'a');
-      jasmine.Clock.tick(1);
-      var result = spf.array.map(nodes, function(a) { return a.href; });
-      expect(result).toContain('//test/url-a-1.css');
-      expect(result).toContain('//test/url-a-2.css');
-      // Remove them (and check that they are no longer "ready").
-      spf.net.style.unload('a');
-      result = spf.array.map(nodes, function(a) { return a.href; });
-      expect('//test/url-a-1.css' in spf.net.resource.stats_).toBe(false);
-      expect('//test/url-a-2.css' in spf.net.resource.stats_).toBe(false);
-      expect(result).not.toContain('//test/url-a-1.css');
-      expect(result).not.toContain('//test/url-a-2.css');
-      // Repeated calls should be no-ops.
-      spf.net.style.unload('a');
-      spf.net.style.unload('a');
-      result = spf.array.map(nodes, function(a) { return a.href; });
-      expect('//test/url-a-1.css' in spf.net.resource.stats_).toBe(false);
-      expect('//test/url-a-2.css' in spf.net.resource.stats_).toBe(false);
-      expect(result).not.toContain('//test/url-a-1.css');
-      expect(result).not.toContain('//test/url-a-2.css');
-      // Check multiple names.
-      spf.net.style.load(['url-a-1.css', 'url-a-2.css'], 'a');
-      spf.net.style.load(['url-b-1.css', 'url-b-2.css'], 'b');
-      jasmine.Clock.tick(1);
-      var result = spf.array.map(nodes, function(a) { return a.href; });
-      expect(result).toContain('//test/url-a-1.css');
-      expect(result).toContain('//test/url-a-2.css');
-      expect(result).toContain('//test/url-b-1.css');
-      expect(result).toContain('//test/url-b-2.css');
-      spf.net.style.unload('b');
-      result = spf.array.map(nodes, function(a) { return a.href; });
-      expect(result).toContain('//test/url-a-1.css');
-      expect(result).toContain('//test/url-a-2.css');
-      expect(result).not.toContain('//test/url-b-1.css');
-      expect(result).not.toContain('//test/url-b-2.css');
-      spf.net.style.unload('a');
-      result = spf.array.map(nodes, function(a) { return a.href; });
-      expect(result).not.toContain('//test/url-a-1.css');
-      expect(result).not.toContain('//test/url-a-2.css');
-      expect(result).not.toContain('//test/url-b-1.css');
-      expect(result).not.toContain('//test/url-b-2.css');
+    it('passes name', function() {
+      var name = 'a';
+      spf.net.style.unload(name);
+      expect(spf.net.resource.unload).toHaveBeenCalledWith(css, name);
     });
 
   });
+
+
+  describe('get', function() {
+
+    it('passes url', function() {
+      var url = 'url-a.css';
+      spf.net.style.get(url);
+      expect(spf.net.resource.create).toHaveBeenCalledWith(
+          css, url, undefined);
+    });
+
+    it('passes url with function', function() {
+      var url = 'url-a.css';
+      var fn = function() {};
+      spf.net.style.get(url, fn);
+      expect(spf.net.resource.create).toHaveBeenCalledWith(
+          css, url, fn);
+    });
+
+  });
+
+
+  describe('prefetch', function() {
+
+    it('calls for a single url', function() {
+      var url = 'url-a.css';
+      spf.net.style.prefetch(url);
+      expect(spf.net.resource.prefetch).toHaveBeenCalledWith(
+          css, url);
+    });
+
+    it('calls for multiples urls', function() {
+      var urls = ['url-a-1.css', 'url-a-2.css'];
+      spf.net.style.prefetch(urls);
+      spf.array.each(urls, function(url) {
+        expect(spf.net.resource.prefetch).toHaveBeenCalledWith(
+            css, url);
+      });
+    });
+
+  });
+
 
 });


### PR DESCRIPTION
Moves common code from spf.net.script and spf.net.style into spf.net.resource.
Reduces duplication and enforces consistency between the script and style
execution/loading models.

Progress on #25.
