### PR TITLE
Standardize build output naming.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ PYTHON = $(shell command -v python || echo _missing_python_)
 
 # Always execute targets.
 .PHONY: default all tests demo lint fix clean reset
-.PHONY: spf debug-spf tracing-spf
-.PHONY: bootloader debug-bootloader tracing-bootloader
+.PHONY: spf spf-debug spf-trace
+.PHONY: boot boot-debug boot-trace
 
 
 # Require Ninja.
 default all tests demo lint fix: $(NINJA)
-spf debug-spf tracing-spf: $(NINJA)
-bootloader debug-bootloader tracing-bootloader: $(NINJA)
+spf spf-debug spf-trace: $(NINJA)
+boot boot-debug boot-trace: $(NINJA)
 
 
 # Pass off builds to Ninja.
@@ -27,16 +27,16 @@ all:
 	@$(NINJA) all
 spf:
 	@$(NINJA) spf
-debug-spf:
-	@$(NINJA) debug-spf
-tracing-spf:
-	@$(NINJA) tracing-spf
-bootloader:
-	@$(NINJA) bootloader
-debug-bootloader:
-	@$(NINJA) debug-bootloader
-tracing-bootloader:
-	@$(NINJA) tracing-bootloader
+spf-debug:
+	@$(NINJA) spf-debug
+spf-trace:
+	@$(NINJA) spf-trace
+boot:
+	@$(NINJA) boot
+boot-debug:
+	@$(NINJA) boot-debug
+boot-trace:
+	@$(NINJA) boot-trace
 tests:
 	@$(NINJA) tests
 	@if [[ $$(command -v phantomjs) ]]; then \

--- a/configure.py
+++ b/configure.py
@@ -480,23 +480,23 @@ def write_targets(ninja):
   ninja.build('$builddir/spf.js', 'jscompile', js_srcs,
               variables=[('flags', '$prod_jsflags $main_jsflags')],
               implicit=[jscompiler_jar, license_js, wrapper_js])
-  ninja.build('$builddir/debug-spf.js', 'jscompile', js_srcs,
+  ninja.build('$builddir/spf-debug.js', 'jscompile', js_srcs,
               variables=[('flags', '$debug_jsflags $main_jsflags')],
               implicit=[jscompiler_jar, license_js, wrapper_js])
-  ninja.build('$builddir/tracing-spf.js', 'jscompile', js_srcs,
+  ninja.build('$builddir/spf-trace.js', 'jscompile', js_srcs,
               variables=[('flags', '$trace_jsflags $main_jsflags'),
                          ('preamble', 'head -n 6 ' + wtf_shim)],
               implicit=[jscompiler_jar, license_js, wrapper_js])
 
   ninja.newline()
   ninja.comment('Bootloader.')
-  ninja.build('$builddir/bootloader.js', 'jscompile', js_srcs,
+  ninja.build('$builddir/boot.js', 'jscompile', js_srcs,
               variables=[('flags', '$prod_jsflags $bootloader_jsflags')],
               implicit=[jscompiler_jar, license_js])
-  ninja.build('$builddir/debug-bootloader.js', 'jscompile', js_srcs,
+  ninja.build('$builddir/boot-debug.js', 'jscompile', js_srcs,
               variables=[('flags', '$debug_jsflags $bootloader_jsflags')],
               implicit=[jscompiler_jar, license_js])
-  ninja.build('$builddir/tracing-bootloader.js', 'jscompile', js_srcs,
+  ninja.build('$builddir/boot-trace.js', 'jscompile', js_srcs,
               variables=[('flags', '$trace_jsflags $bootloader_jsflags'),
                          ('preamble', 'head -n 6 ' + wtf_shim)],
               implicit=[jscompiler_jar, license_js])
@@ -581,16 +581,16 @@ def write_aliases(ninja):
   aliases = [
       ninja.build('spf', 'phony',
                   '$builddir/spf.js'),
-      ninja.build('debug-spf', 'phony',
-                  '$builddir/debug-spf.js'),
-      ninja.build('tracing-spf', 'phony',
-                  '$builddir/tracing-spf.js'),
+      ninja.build('spf-debug', 'phony',
+                  '$builddir/spf-debug.js'),
+      ninja.build('spf-trace', 'phony',
+                  '$builddir/spf-trace.js'),
       ninja.build('bootloader', 'phony',
-                  '$builddir/bootloader.js'),
+                  '$builddir/boot.js'),
       ninja.build('debug-bootloader', 'phony',
-                  '$builddir/debug-bootloader.js'),
+                  '$builddir/boot-debug.js'),
       ninja.build('tracing-bootloader', 'phony',
-                  '$builddir/tracing-bootloader.js'),
+                  '$builddir/boot-trace.js'),
       ninja.build('tests', 'phony',
                   '$builddir/test/runner.html'),
       ninja.build('demo', 'phony',


### PR DESCRIPTION
Build output changes are as follows:

```
spf.js  ->  spf.js
debug-spf.js  ->  spf-debug.js
tracing-spf.js  -> spf-trace.js
bootloader.js  ->  boot.js
debug-bootloader.js  ->  boot-debug.js
tracing-bootloader.js  ->  boot-trace.js
```

Closes #18.
