### PR TITLE
Provide UMD compatibility.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -179,12 +179,11 @@ def write_variables(ninja):
   ninja.variable('license_js', 'src/license.js')
   ninja.variable('license', 'cat $license_js')
   ninja.variable('preamble', 'true')
+  ninja.variable('wrapper_js', 'src/wrapper.js')
 
   common_jsflags = [
       '--compilation_level ADVANCED_OPTIMIZATIONS',
       '--define "COMPILED=true"',
-      '--define "SPF_COMPILED=true"',
-      '--output_wrapper "(function(){%output%})();"',
       '--manage_closure_dependencies true',
       '--process_closure_primitives true',
   ]
@@ -208,9 +207,11 @@ def write_variables(ninja):
   ]
   main_jsflags = [
       '--closure_entry_point spf.main',
+      '--output_wrapper_file $wrapper_js',
   ]
   bootloader_jsflags = [
       '--closure_entry_point spf.bootloader',
+      '--output_wrapper "(function(){%output%})();"',
   ]
   ninja.variable('prod_jsflags', ' '.join(prod_jsflags))
   ninja.variable('debug_jsflags', ' '.join(debug_jsflags))
@@ -296,6 +297,7 @@ def write_rules(ninja):
 
 def write_targets(ninja):
   license_js = '$license_js'
+  wrapper_js = '$wrapper_js'
 
   ninja.newline()
   ninja.comment('Libraries.')
@@ -477,14 +479,14 @@ def write_targets(ninja):
   ninja.comment('Main.')
   ninja.build('$builddir/spf.js', 'jscompile', js_srcs,
               variables=[('flags', '$prod_jsflags $main_jsflags')],
-              implicit=[jscompiler_jar, license_js])
+              implicit=[jscompiler_jar, license_js, wrapper_js])
   ninja.build('$builddir/debug-spf.js', 'jscompile', js_srcs,
               variables=[('flags', '$debug_jsflags $main_jsflags')],
-              implicit=[jscompiler_jar, license_js])
+              implicit=[jscompiler_jar, license_js, wrapper_js])
   ninja.build('$builddir/tracing-spf.js', 'jscompile', js_srcs,
               variables=[('flags', '$trace_jsflags $main_jsflags'),
                          ('preamble', 'head -n 6 ' + wtf_shim)],
-              implicit=[jscompiler_jar, license_js])
+              implicit=[jscompiler_jar, license_js, wrapper_js])
 
   ninja.newline()
   ninja.comment('Bootloader.')

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -34,10 +34,6 @@ goog.provide('spf');
 var SPF_BOOTLOADER = false;
 
 
-/** @define {boolean} Compiler flag to remove development code. */
-var SPF_COMPILED = false;
-
-
 /** @define {boolean} Compiler flag to include debugging code. */
 var SPF_DEBUG = true;
 

--- a/src/client/bootloader.js
+++ b/src/client/bootloader.js
@@ -21,7 +21,7 @@ goog.require('spf.net.script');
 
 
 // Create the bootloader API by exporting aliased functions.
-/** @private {Object} */
+/** @private {!Object} */
 spf.bootloader.api_ = {
   'script': {
     // The bootloader API.
@@ -38,13 +38,11 @@ spf.bootloader.api_ = {
     'path': spf.net.script.path
   }
 };
-if (!SPF_COMPILED) {
-  // When not compiled, mixin the API to the existing namespace for development.
-  for (var key in spf.bootloader.api_) {
-    // Work around the "incomplete alias" warning.
-    eval('spf[key] = spf.bootloader.api_[key]');
-  }
-} else {
-  // When compiled for a production/debug build, isolate access to the API.
-  window['spf'] = spf.bootloader.api_;
+// For a production/debug build, isolate access to the API.
+// For a development build, mixin the API to the existing namespace.
+var global = this;
+global['spf'] = global['spf'] || {};
+var api = global['spf'];
+for (var fn in spf.bootloader.api_) {
+  api[fn] = spf.bootloader.api_[fn];
 }

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -98,7 +98,7 @@ spf.main.discover_();
 // Create the API by exporting aliased functions.
 // Core API functions are available on the top-level namespace.
 // Extra API functions are available on second-level namespaces.
-/** @private {Object} */
+/** @private {!Object} */
 spf.main.api_ = {
   'init': spf.main.init,
   'dispose': spf.main.dispose,
@@ -107,7 +107,7 @@ spf.main.api_ = {
   'process': spf.nav.response.process,  // TODO: Remove after deprecation.
   'prefetch': spf.nav.prefetch
 };
-/** @private {Object} */
+/** @private {!Object} */
 spf.main.extra_ = {
   'script': {
     // The bootloader API.
@@ -145,34 +145,21 @@ spf.main.extra_ = {
     'prefetch': spf.net.style.prefetch
   }
 };
-if (!SPF_COMPILED) {
-  // When not compiled, mixin the API to the existing namespace for development.
-  // Use eval to work around the "incomplete alias" warning.
-  for (var fn1 in spf.main.api_) {
-    eval('spf[fn1] = spf.main.api_[fn1]');
+// For a production/debug build, isolate access to the API.
+// For a development build, mixin the API to the existing namespace.
+var global = this;
+global['spf'] = global['spf'] || {};
+var api = global['spf'];
+for (var fn1 in spf.main.api_) {
+  api[fn1] = spf.main.api_[fn1];
+}
+// Use two-stage exporting to allow aliasing the intermediate namespaces
+// created by the bootloader (e.g. s = spf.script; s.load(...)).
+for (var ns in spf.main.extra_) {
+  for (var fn2 in spf.main.extra_[ns]) {
+    api[ns] = api[ns] || {};
+    api[ns][fn2] = spf.main.extra_[ns][fn2];
   }
-  for (var ns in spf.main.extra_) {
-    for (var fn2 in spf.main.extra_[ns]) {
-      eval('spf[ns] = spf[ns] || {};');
-      eval('spf[ns][fn2] = spf.main.extra_[ns][fn2]');
-    }
-  }
-} else {
-  // When compiled for a production/debug build, isolate access to the API.
-  (function() {
-    window['spf'] = window['spf'] || {};
-    for (var fn1 in spf.main.api_) {
-      window['spf'][fn1] = spf.main.api_[fn1];
-    }
-    // Use two-stage exporting to allow aliasing the intermediate namespaces
-    // created by the bootloader (e.g. s = spf.script; s.load(...)).
-    for (var ns in spf.main.extra_) {
-      for (var fn2 in spf.main.extra_[ns]) {
-        window['spf'][ns] = window['spf'][ns] || {};
-        window['spf'][ns][fn2] = spf.main.extra_[ns][fn2];
-      }
-    }
-  })();
 }
 
 // Signal that the API is ready with custom event.  Only supported in IE 9+.

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -1,0 +1,1 @@
+(function(){%output%if(typeof define=='function'&&define.amd)define(spf);else if(typeof exports=='object')for(var f in spf)exports[f]=spf[f];})();


### PR DESCRIPTION
- Ensure build output is wrapped to support both AMD (e.g. RequireJS) and
  CommonJS (e.g. Browserify) module formats.
- Use a dedicated wrapper.js file since the complexity has grown.
- Streamline how the API is defined for both the main and bootloader binaries
  to reduce boilerplate.

Closes #40.
