### PR TITLE
Add reload reason text with an error number to the reload event.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -303,6 +303,13 @@ spf.EventDetail.prototype.previous;
 
 
 /**
+ * A string containing a reason code and a text explanation (debug only);
+ * defined for the "spfreload" event.
+ */
+spf.EventDetail.prototype.reason;
+
+
+/**
  * The URL of the previous page; defined for "spfhistory" and
  * "spfrequest" events.
  * @type {string|undefined}


### PR DESCRIPTION
I couldn't decide whether I wanted readable messages, for easier debugging, or reason codes, for easier logs analysis, so I just did both. Opinions welcome.

Alex, several of these situations can be removed once the deprecated events are gone. So if you're planning on doing that soon, I could hold off on these changes for a bit.
