### PR TITLE
Remove deprecated navigation events and update API definition.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -180,28 +180,64 @@ spf.RequestOptions.prototype.onError;
 
 
 /**
+ * Optional callback to execute before sending a SPF request. The argument
+ * to the callback will be an object that conforms to the
+ * {@code spf.EventDetail} interface for "spfrequest" events (see
+ * {@link spf.Event}).
+ * @type {function(spf.EventDetail)|undefined}
+ */
+spf.RequestOptions.prototype.onRequest;
+
+
+/**
  * Optional callback to execute upon receiving a part of a multipart SPF
- * response (see {@link spf.MultipartResponse}).  Called before
- * {@code onSuccess}, once per part of multipart responses; never called for
+ * response (see {@link spf.MultipartResponse}).  Called before the part is
+ * processed, once per part of multipart responses; never called for
  * single responses. If valid "X-SPF-Response-Type: multipart" and
  * "Transfer-Encoding: chunked" headers are sent, then this callback will be
  * executed on-the-fly as chunks are received.  The argument to the
  * callback will be an object that conforms to the {@code spf.EventDetail}
- * interface for "spfpartreceived" and "spfpartprocessed" events
- * (see {@link spf.Event}).
+ * interface for "spfpartprocess" events (see {@link spf.Event}).
  * @type {function(spf.EventDetail)|undefined}
  */
-spf.RequestOptions.prototype.onPart;
+spf.RequestOptions.prototype.onPartProcess;
 
 
 /**
- * Optional callback to execute if the request succeeds.  The argument to the
- * callback will be an object that conforms to the {@code spf.EventDetail}
- * interface for "spfreceived" and "spfprocessed" events
- * (see {@link spf.Event}).
+ * Optional callback to execute after processing a part of a multipart SPF
+ * response (see {@link spf.MultipartResponse}). Called once per part of
+ * multipart responses; never called for single responses. If valid
+ * "X-SPF-Response-Type: multipart" and "Transfer-Encoding: chunked"
+ * headers are sent, then this callback will be executed on-the-fly as
+ * chunks are received. The argument to the callback will be an object
+ * that conforms to the {@code spf.EventDetail} interface for
+ * "spfpartdone" events (see {@link spf.Event}).
  * @type {function(spf.EventDetail)|undefined}
  */
-spf.RequestOptions.prototype.onSuccess;
+spf.RequestOptions.prototype.onPartDone;
+
+
+/**
+ * Optional callback to execute upon receiving a single SPF response (see
+ * {@link spf.SingleResponse}). Called before the response is processed;
+ * never called for multipart responses. The argument to the callback will
+ * be an object that conforms to the {@code spf.EventDetail} interface for
+ * "spfprocess" events (see {@link spf.Event}).
+ * @type {function(spf.EventDetail)|undefined}
+ */
+spf.RequestOptions.prototype.onProcess;
+
+
+/**
+ * Optional callback to execute when the response is done being processed.
+ * Called once as the last event for both single and multipart responses (see
+ * {@link spf.SingleResponse} and {@link spf.MultipartResponse}).  The argument
+ * to the callback will be an object that conforms to the
+ * {@code spf.EventDetail} interface for "spfdone" events (see
+ * {@link spf.Event}).
+ * @type {function(spf.EventDetail)|undefined}
+ */
+spf.RequestOptions.prototype.onDone;
 
 
 /**
@@ -252,24 +288,49 @@ spf.EventDetail.prototype.name;
 
 /**
  * One part of a multipart SPF response (see {@link spf.MultipartResponse});
- * defined for "spfpartreceived" and "spfpartprocessed" events.
+ * defined for "spfpartprocess" and "spfpartdone" events.
  * @type {spf.SingleResponse|undefined}
  */
 spf.EventDetail.prototype.part;
 
 
 /**
- * A complete SPF response (see {@link spf.SingleResponse} and
- * {@link spf.MultipartResponse}); defined for "spfreceived" and "spfprocessed"
- * events.
+ * The URL of the previous page; defined for "spfhistory" and
+ * "spfrequest" events.
+ * @type {string|undefined}
+ */
+spf.EventDetail.prototype.previous;
+
+
+/**
+ * The URL of the previous page; defined for "spfhistory" and
+ * "spfrequest" events.
+ * @type {string|undefined}
+ */
+spf.EventDetail.prototype.referer;
+
+
+/**
+ * A complete SPF response; defined for "spfprocess" events as a single
+ * response and for "spfdone" events as either a single or multipart
+ * response (see {@link spf.SingleResponse} and {@link
+ * spf.MultipartResponse}.
  * @type {spf.SingleResponse|spf.MultipartResponse|undefined}
  */
 spf.EventDetail.prototype.response;
 
 
 /**
- * The URL of the request; defined for "spfrequested", "spfpartreceived",
- * "spfpartprocessed", "spfreceived", "spfprocessed", and "spferror" events.
+ * The target element of a click; defined for "spfclick" events.
+ * @type {Element|undefined}
+ */
+spf.EventDetail.prototype.target;
+
+
+/**
+ * The URL of the request; defined for "spferror", "spfreload", "spfclick",
+ * "spfhistory", "spfrequest", "spfpartprocess", "spfpartdone", "spfprocess",
+ * and "spfdone" events.
  * @type {string|undefined}
  */
 spf.EventDetail.prototype.url;

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -166,29 +166,26 @@ spf.MultipartResponse;
 /**
  * Type definition for the configuration options for requesting a URL.
  * - method: optional method with which to send the request; defaults to "GET".
- * - onError: optional callback to execute if the request fails. The first
- *       argument is the requested URL; the second argument is the Error that
- *       occurred.
- * - onPart: optional callback to execute upon receiving a part of a multipart
- *       SPF response (see {@link spf.MultipartResponse}).  Called before
- *       {@code onSuccess}, once per part of multipart responses; never called
- *       for single responses. If valid "X-SPF-Response-Type: multipart" and
- *       "Transfer-Encoding: chunked" headers are sent, then this callback will
- *       be executed on-the-fly as chunks are received.  The first argument is
- *       the requested URL; the second is the partial response object.
- * - onSuccess: optional callback to execute if the request succeeds.  The first
- *       argument is the requested URL; the second is the response object.  The
- *       response object will be either a complete single response object or
- *       a complete multipart response object.
- * - postData: optional data to send with a request.  Only used if the method is
- *       set to "POST".
+ * - postData: optional data to send with a request.  Only used if the method
+ *       is set to "POST".
+ * - onError: optional callback if an error occurs.
+ * - onRequest: optional callback when a request will be made.
+ * - onPartProcess: optional callback when part of a multipart response
+ *       will be processed.
+ * - onPartDone: optional callback when part of a multipart response
+ *       is done being processed.
+ * - onProcess: optional callback when a single response will be processed.
+ * - onDone: optional callback when either repsonse is done being processed.
  *
  * @typedef {{
  *   postData: (ArrayBuffer|Blob|Document|FormData|null|string|undefined),
  *   method: (string|undefined),
  *   onError: (function(spf.EventDetail)|undefined),
- *   onPart: (function(spf.EventDetail)|undefined),
- *   onSuccess: (function(spf.EventDetail)|undefined)
+ *   onRequest: (function(spf.EventDetail)|undefined),
+ *   onPartProcess: (function(spf.EventDetail)|undefined),
+ *   onPartDone: (function(spf.EventDetail)|undefined),
+ *   onProcess: (function(spf.EventDetail)|undefined),
+ *   onDone: (function(spf.EventDetail)|undefined)
  * }}
  */
 spf.RequestOptions;
@@ -196,16 +193,22 @@ spf.RequestOptions;
 
 /**
  * Type definititon for custom event detail (data), also used for callbacks.
- * - err: optional error that occurred; defined for "spferror" events
+ * - err: optional error that occurred; defined for "error" events
  * - name: optional name of the scripts or styles that will be unloaded;
  *       defined for "jsbeforeunload", "jsunload", "cssbeforeunload",
  *       and "cssunload" events.
- * - part: optional part of a multipart response; defined for "partreceived"
- *       and "partprocessed" events.
- * - response: optional complete response; defined for "received" and
- *       "processed" events.
- * - url: optional URL of the request; defined for "requested", "partreceived",
- *       "partprocessed", "received", "processed", and "error" events.
+ * - part: optional part of a multipart response; defined for "partprocess"
+ *       and "partdone" events.
+ * - previous: optional URL of the previous page; defined for "history" and
+ *       "request" events.
+ * - referer: optional URL of the referer page; defined for "history" and
+ *       "request" events.
+ * - response: optional complete response; defined for "process" and
+ *       "done" events.
+ * - target: optional target element; defined for "click" events.
+ * - url: optional URL of the request; defined for "error", "reload", "click",
+ *       "history", "request", "partprocess", "partdone", "process", and "done"
+ *       events.
  * - urls: optional list or URLs of scripts/styles to be unloaded; defined for
  *       "jsbeforeunload", "jsunload", "cssbeforeunload", and "cssunload"
  *       events.
@@ -214,6 +217,9 @@ spf.RequestOptions;
  *   err: (Error|undefined),
  *   name: (string|undefined),
  *   part: (spf.SingleResponse|undefined),
+ *   previous: (string|undefined),
+ *   referer: (string|undefined),
+ *   target: (Element|undefined),
  *   response: (spf.SingleResponse|spf.MultipartResponse|undefined),
  *   url: (string|undefined),
  *   urls: (Array.<string>|undefined)


### PR DESCRIPTION
Closes #12.
