### PR TITLE
Calculate prefetched value

### DIFF
--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -593,7 +593,7 @@ spf.nav.handleNavigateSuccess_ = function(options, reverse, original,
   if (spf.state.get('nav-promote') == original) {
     var timing = response['timing'] || {};
     timing['navigationStart'] = spf.state.get('nav-promote-time');
-    timing['spfPrefetchType'] = 'promote';
+    timing['spfPrefetched'] = true;
   }
 
   // If a multipart response was received, all processing is already done,

--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -99,6 +99,7 @@ spf.nav.request.send = function(url, opt_options) {
   // Use the absolute URL without identifier to allow cached responses
   // from prefetching to apply to navigation.
   var cached = spf.nav.request.getCacheObject_(cacheKey, options.current);
+  timing['spfPrefetched'] = !!cached && cached.type == 'prefetch';
   timing['spfCached'] = !!cached;
   if (cached) {
     var response = /** @type {spf.SingleResponse|spf.MultipartResponse} */ (
@@ -174,8 +175,6 @@ spf.nav.request.handleResponseFromCache_ = function(url, options, timing,
   // W3C PerformanceTiming for page loads.
   if (options.type && spf.string.startsWith(options.type, 'navigate')) {
     timing['navigationStart'] = timing['startTime'];
-    // Record that this prefetched response is a cache hit.
-    timing['spfPrefetchType'] = 'cache';
     // If this cached response was a navigate and a unified cache is not being
     // used, then it was from prefetch-based caching and is only eligible to
     // be used once.
@@ -400,7 +399,7 @@ spf.nav.request.done_ = function(url, options, timing, response, cache) {
                                                 response['cacheType'],
                                                 options.type, true);
     if (cacheKey) {
-      spf.nav.request.setCacheObject_(cacheKey, response);
+      spf.nav.request.setCacheObject_(cacheKey, response, options.type || '');
     }
   }
   // Set the timing for the response (avoid caching stale timing values).
@@ -483,7 +482,8 @@ spf.nav.request.getCacheObject_ = function(cacheKey, opt_current) {
     if (cached) {
       return {
         key: keys[i],
-        response: cached
+        response: cached['response'],
+        type: cached['type']
       };
     }
   }
@@ -497,10 +497,15 @@ spf.nav.request.getCacheObject_ = function(cacheKey, opt_current) {
  * @param {string} cacheKey The base cache key for the requested URL.
  * @param {spf.SingleResponse|spf.MultipartResponse} response The received SPF
  *     response object.
+ * @param {string} type The type of request this cache entry was set with.
  * @private
  */
-spf.nav.request.setCacheObject_ = function(cacheKey, response) {
-  spf.cache.set(cacheKey, response,  /** @type {number} */ (
+spf.nav.request.setCacheObject_ = function(cacheKey, response, type) {
+  var cacheValue = {
+    'response': response,
+    'type': type
+  };
+  spf.cache.set(cacheKey, cacheValue,  /** @type {number} */ (
       spf.config.get('cache-lifetime')));
 };
 

--- a/src/client/nav/request_test.js
+++ b/src/client/nav/request_test.js
@@ -111,7 +111,11 @@ describe('spf.nav.request', function() {
       var res = {'foo': 'FOO', 'bar': 'BAR'};
 
       var cacheKey = 'prefetch ' + spf.url.absolute(url);
-      spf.cache.set(cacheKey, res);
+      var cacheObject = {
+        'response': res,
+        'type': 'prefetch'
+      };
+      spf.cache.set(cacheKey, cacheObject);
 
       var requestUrl = spf.url.identify(url, options.type);
       spf.nav.request.send(url, options);
@@ -136,7 +140,11 @@ describe('spf.nav.request', function() {
       };
 
       var cacheKey = 'prefetch ' + spf.url.absolute(url);
-      spf.cache.set(cacheKey, res);
+      var cacheObject = {
+        'response': res,
+        'type': 'prefetch'
+      };
+      spf.cache.set(cacheKey, cacheObject);
 
       var requestUrl = spf.url.identify(url, options.type);
       spf.nav.request.send(url, options);
@@ -160,7 +168,11 @@ describe('spf.nav.request', function() {
       var res = {'foo': 'FOO', 'bar': 'BAR'};
 
       var cacheKey = 'prefetch ' + spf.url.absolute(url) + ' previous ' + path;
-      spf.cache.set(cacheKey, res);
+      var cacheObject = {
+        'response': res,
+        'type': 'prefetch'
+      };
+      spf.cache.set(cacheKey, cacheObject);
 
       spf.nav.request.send(url, options);
 
@@ -185,7 +197,11 @@ describe('spf.nav.request', function() {
       var xhrText = '{"foo": "FOO", "baz": "BAZ"}';
 
       var cacheKey = 'prefetch ' + spf.url.absolute(url) + ' previous ' + path;
-      spf.cache.set(cacheKey, cacheRes);
+      var cacheObject = {
+        'response': cacheRes,
+        'type': 'prefetch'
+      };
+      spf.cache.set(cacheKey, cacheObject);
 
       var fake = createFakeRegularXHR(xhrText);
       spf.net.xhr.get = jasmine.createSpy('xhr.get').andCallFake(fake);
@@ -914,7 +930,11 @@ describe('spf.nav.request', function() {
       var startTime = new Date().getTime() - 1;
 
       var cacheKey = 'prefetch ' + spf.url.absolute(url);
-      spf.cache.set(cacheKey, res);
+      var cacheObject = {
+        'response': res,
+        'type': 'prefetch'
+      };
+      spf.cache.set(cacheKey, cacheObject);
 
       var requestUrl = spf.url.identify(url, options.type);
       spf.nav.request.send(url, options);
@@ -930,5 +950,20 @@ describe('spf.nav.request', function() {
 
   });
 
+  describe('cache object', function() {
+
+    it('preserves cache type', function() {
+      var key = 'key';
+      var response = {
+        parts: [{'foo': 'FOO'}, {'bar': 'BAR'}],
+        type: 'multipart'
+      };
+      var type = 'prefetch';
+      spf.nav.request.setCacheObject_(key, response, type);
+      var cached = spf.nav.request.getCacheObject_(key);
+      expect(cached['response']).toBe(response);
+      expect(cached['type']).toBe(type);
+    });
+  });
 
 });


### PR DESCRIPTION
Calculate the prefetched value as opposed to a prefetchType

`spfPrefetch` contains the boolean value of whether the request was a prefetch or not.

`spfPrefetch && !spfCached` implies the request was a promote
`spfPrefetch && spfCached` implies a prefetch cache hit
