### PR TITLE
Add experimental "unified execution" for scripts and styles.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -464,7 +464,6 @@ spf.script.unload = function(name) {};
  *
  * @param {string} url The URL of the script to load.
  * @param {Function=} opt_fn Function to execute when loaded.
- * @return {Element} The newly created element.
  */
 spf.script.get = function(url, opt_fn) {};
 
@@ -603,7 +602,6 @@ spf.style.unload = function(name) {};
  * Compare to {@link #load}.
  *
  * @param {string} url The URL of the style to load.
- * @return {Element} The newly created element.
  */
 spf.style.get = function(url) {};
 

--- a/src/client/net/resource_test.js
+++ b/src/client/net/resource_test.js
@@ -16,10 +16,10 @@ goog.require('spf.url');
 
 describe('spf.net.resource', function() {
 
-  var js = spf.net.resource.Type.JS;
-  var css = spf.net.resource.Type.CSS;
-  var loading = spf.net.resource.Status.LOADING;
-  var loaded = spf.net.resource.Status.LOADED;
+  var JS = spf.net.resource.Type.JS;
+  var CSS = spf.net.resource.Type.CSS;
+  var LOADING = spf.net.resource.State.LOADING;
+  var LOADED = spf.net.resource.State.LOADED;
   var nodes;
   var callbacks;
   var reals = {
@@ -121,7 +121,7 @@ describe('spf.net.resource', function() {
     spf.state.values_ = {};
     spf.pubsub.subscriptions = {};
     spf.net.resource.urls_ = {};
-    spf.net.resource.stats_ = {};
+    spf.net.resource.status_ = {};
 
     nodes = [new FakeElement('head')];
     callbacks = {
@@ -140,113 +140,113 @@ describe('spf.net.resource', function() {
   describe('load', function() {
 
     it('a single url (script)', function() {
-      spf.net.resource.load(js, 'url-a.js');
+      spf.net.resource.load(JS, 'url-a.js');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(1);
-      spf.net.resource.load(js, 'url-a.js');
+      spf.net.resource.load(JS, 'url-a.js');
       jasmine.Clock.tick(1);
-      spf.net.resource.load(js, 'url-a.js');
+      spf.net.resource.load(JS, 'url-a.js');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(1);
-      spf.net.resource.load(js, 'url-b.js');
+      spf.net.resource.load(JS, 'url-b.js');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(2);
     });
 
     it('a single url (style)', function() {
-      spf.net.resource.load(css, 'url-a.css');
+      spf.net.resource.load(CSS, 'url-a.css');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(1);
-      spf.net.resource.load(css, 'url-a.css');
+      spf.net.resource.load(CSS, 'url-a.css');
       jasmine.Clock.tick(1);
-      spf.net.resource.load(css, 'url-a.css');
+      spf.net.resource.load(CSS, 'url-a.css');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(1);
-      spf.net.resource.load(css, 'url-b.css');
+      spf.net.resource.load(CSS, 'url-b.css');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(2);
     });
 
     it('a single url with a name (script)', function() {
-      spf.net.resource.load(js, 'url-a.js', 'a');
+      spf.net.resource.load(JS, 'url-a.js', 'a');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(1);
-      spf.net.resource.load(js, 'url-a.js', 'a');
+      spf.net.resource.load(JS, 'url-a.js', 'a');
       jasmine.Clock.tick(1);
-      spf.net.resource.load(js, 'url-a.js', 'a');
+      spf.net.resource.load(JS, 'url-a.js', 'a');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(1);
-      spf.net.resource.load(js, 'url-b.js', 'b');
+      spf.net.resource.load(JS, 'url-b.js', 'b');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(2);
     });
 
     it('a single url with a name (style)', function() {
-      spf.net.resource.load(css, 'url-a.css', 'a');
+      spf.net.resource.load(CSS, 'url-a.css', 'a');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(1);
-      spf.net.resource.load(css, 'url-a.css', 'a');
+      spf.net.resource.load(CSS, 'url-a.css', 'a');
       jasmine.Clock.tick(1);
-      spf.net.resource.load(css, 'url-a.css', 'a');
+      spf.net.resource.load(CSS, 'url-a.css', 'a');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(1);
-      spf.net.resource.load(css, 'url-b.css', 'b');
+      spf.net.resource.load(CSS, 'url-b.css', 'b');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(2);
     });
 
     it('multiple urls (script)', function() {
-      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js']);
+      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js']);
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(2);
-      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js']);
+      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js']);
       jasmine.Clock.tick(1);
-      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js']);
+      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js']);
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(2);
-      spf.net.resource.load(js, ['url-b-1.js', 'url-b-2.js']);
+      spf.net.resource.load(JS, ['url-b-1.js', 'url-b-2.js']);
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(4);
     });
 
     it('multiple urls (style)', function() {
-      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css']);
+      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css']);
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(2);
-      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css']);
+      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css']);
       jasmine.Clock.tick(1);
-      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css']);
+      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css']);
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(2);
-      spf.net.resource.load(css, ['url-b-1.css', 'url-b-2.css']);
+      spf.net.resource.load(CSS, ['url-b-1.css', 'url-b-2.css']);
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(4);
     });
 
     it('multiple urls with a name (script)', function() {
-      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
+      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(2);
-      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
+      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
       jasmine.Clock.tick(1);
-      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
+      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(2);
-      spf.net.resource.load(js, ['url-b-1.js', 'url-b-2.js'], 'b');
+      spf.net.resource.load(JS, ['url-b-1.js', 'url-b-2.js'], 'b');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(4);
     });
 
     it('multiple urls with a name (style)', function() {
-      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
+      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(2);
-      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
+      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
       jasmine.Clock.tick(1);
-      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
+      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(2);
-      spf.net.resource.load(css, ['url-b-1.css', 'url-b-2.css'], 'b');
+      spf.net.resource.load(CSS, ['url-b-1.css', 'url-b-2.css'], 'b');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(4);
     });
@@ -258,69 +258,69 @@ describe('spf.net.resource', function() {
 
     it('a single url by name (script)', function() {
       // Load a URL.
-      spf.net.resource.load(js, 'url-a.js', 'a');
+      spf.net.resource.load(JS, 'url-a.js', 'a');
       jasmine.Clock.tick(1);
       expect(getScriptUrls()).toContain('//test/url-a.js');
       // Unload it.
-      spf.net.resource.unload(js, 'a');
-      expect('//test/url-a.js' in spf.net.resource.stats_).toBe(false);
+      spf.net.resource.unload(JS, 'a');
+      expect('//test/url-a.js' in spf.net.resource.status_).toBe(false);
       expect(getScriptUrls()).not.toContain('//test/url-a.js');
       // Repeated calls should be no-ops.
-      spf.net.resource.unload(js, 'a');
-      spf.net.resource.unload(js, 'a');
-      expect('//test/url-a.js' in spf.net.resource.stats_).toBe(false);
+      spf.net.resource.unload(JS, 'a');
+      spf.net.resource.unload(JS, 'a');
+      expect('//test/url-a.js' in spf.net.resource.status_).toBe(false);
       expect(getScriptUrls()).not.toContain('//test/url-a.js');
     });
 
     it('a single url by name (style)', function() {
       // Load a URL.
-      spf.net.resource.load(css, 'url-a.css', 'a');
+      spf.net.resource.load(CSS, 'url-a.css', 'a');
       jasmine.Clock.tick(1);
       expect(getStyleUrls()).toContain('//test/url-a.css');
       // Unload it.
-      spf.net.resource.unload(css, 'a');
-      expect('//test/url-a.css' in spf.net.resource.stats_).toBe(false);
+      spf.net.resource.unload(CSS, 'a');
+      expect('//test/url-a.css' in spf.net.resource.status_).toBe(false);
       expect(getStyleUrls()).not.toContain('//test/url-a.css');
       // Repeated calls should be no-ops.
-      spf.net.resource.unload(css, 'a');
-      spf.net.resource.unload(css, 'a');
-      expect('//test/url-a.css' in spf.net.resource.stats_).toBe(false);
+      spf.net.resource.unload(CSS, 'a');
+      spf.net.resource.unload(CSS, 'a');
+      expect('//test/url-a.css' in spf.net.resource.status_).toBe(false);
       expect(getStyleUrls()).not.toContain('//test/url-a.css');
     });
 
     it('multiple urls by name (script)', function() {
       // Load some URLs (and check that they are "ready").
-      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
+      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
       jasmine.Clock.tick(1);
       expect(getScriptUrls()).toContain('//test/url-a-1.js');
       expect(getScriptUrls()).toContain('//test/url-a-2.js');
       // Remove them (and check that they are no longer "ready").
-      spf.net.resource.unload(js, 'a');
-      expect('//test/url-a-1.js' in spf.net.resource.stats_).toBe(false);
-      expect('//test/url-a-2.js' in spf.net.resource.stats_).toBe(false);
+      spf.net.resource.unload(JS, 'a');
+      expect('//test/url-a-1.js' in spf.net.resource.status_).toBe(false);
+      expect('//test/url-a-2.js' in spf.net.resource.status_).toBe(false);
       expect(getScriptUrls()).not.toContain('//test/url-a-1.js');
       expect(getScriptUrls()).not.toContain('//test/url-a-2.js');
       // Repeated calls should be no-ops.
-      spf.net.resource.unload(js, 'a');
-      spf.net.resource.unload(js, 'a');
-      expect('//test/url-a-1.js' in spf.net.resource.stats_).toBe(false);
-      expect('//test/url-a-2.js' in spf.net.resource.stats_).toBe(false);
+      spf.net.resource.unload(JS, 'a');
+      spf.net.resource.unload(JS, 'a');
+      expect('//test/url-a-1.js' in spf.net.resource.status_).toBe(false);
+      expect('//test/url-a-2.js' in spf.net.resource.status_).toBe(false);
       expect(getScriptUrls()).not.toContain('//test/url-a-1.js');
       expect(getScriptUrls()).not.toContain('//test/url-a-2.js');
       // Check multiple names.
-      spf.net.resource.load(js, ['url-a-1.js', 'url-a-2.js'], 'a');
-      spf.net.resource.load(js, ['url-b-1.js', 'url-b-2.js'], 'b');
+      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
+      spf.net.resource.load(JS, ['url-b-1.js', 'url-b-2.js'], 'b');
       jasmine.Clock.tick(1);
       expect(getScriptUrls()).toContain('//test/url-a-1.js');
       expect(getScriptUrls()).toContain('//test/url-a-2.js');
       expect(getScriptUrls()).toContain('//test/url-b-1.js');
       expect(getScriptUrls()).toContain('//test/url-b-2.js');
-      spf.net.resource.unload(js, 'b');
+      spf.net.resource.unload(JS, 'b');
       expect(getScriptUrls()).toContain('//test/url-a-1.js');
       expect(getScriptUrls()).toContain('//test/url-a-2.js');
       expect(getScriptUrls()).not.toContain('//test/url-b-1.js');
       expect(getScriptUrls()).not.toContain('//test/url-b-2.js');
-      spf.net.resource.unload(js, 'a');
+      spf.net.resource.unload(JS, 'a');
       expect(getScriptUrls()).not.toContain('//test/url-a-1.js');
       expect(getScriptUrls()).not.toContain('//test/url-a-2.js');
       expect(getScriptUrls()).not.toContain('//test/url-b-1.js');
@@ -329,37 +329,37 @@ describe('spf.net.resource', function() {
 
     it('multiple urls by name (style)', function() {
       // Load some URLs (and check that they are "ready").
-      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
+      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
       jasmine.Clock.tick(1);
       expect(getStyleUrls()).toContain('//test/url-a-1.css');
       expect(getStyleUrls()).toContain('//test/url-a-2.css');
       // Remove them (and check that they are no longer "ready").
-      spf.net.resource.unload(css, 'a');
-      expect('//test/url-a-1.css' in spf.net.resource.stats_).toBe(false);
-      expect('//test/url-a-2.css' in spf.net.resource.stats_).toBe(false);
+      spf.net.resource.unload(CSS, 'a');
+      expect('//test/url-a-1.css' in spf.net.resource.status_).toBe(false);
+      expect('//test/url-a-2.css' in spf.net.resource.status_).toBe(false);
       expect(getStyleUrls()).not.toContain('//test/url-a-1.css');
       expect(getStyleUrls()).not.toContain('//test/url-a-2.css');
       // Repeated calls should be no-ops.
-      spf.net.resource.unload(css, 'a');
-      spf.net.resource.unload(css, 'a');
-      expect('//test/url-a-1.css' in spf.net.resource.stats_).toBe(false);
-      expect('//test/url-a-2.css' in spf.net.resource.stats_).toBe(false);
+      spf.net.resource.unload(CSS, 'a');
+      spf.net.resource.unload(CSS, 'a');
+      expect('//test/url-a-1.css' in spf.net.resource.status_).toBe(false);
+      expect('//test/url-a-2.css' in spf.net.resource.status_).toBe(false);
       expect(getStyleUrls()).not.toContain('//test/url-a-1.css');
       expect(getStyleUrls()).not.toContain('//test/url-a-2.css');
       // Check multiple names.
-      spf.net.resource.load(css, ['url-a-1.css', 'url-a-2.css'], 'a');
-      spf.net.resource.load(css, ['url-b-1.css', 'url-b-2.css'], 'b');
+      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
+      spf.net.resource.load(CSS, ['url-b-1.css', 'url-b-2.css'], 'b');
       jasmine.Clock.tick(1);
       expect(getStyleUrls()).toContain('//test/url-a-1.css');
       expect(getStyleUrls()).toContain('//test/url-a-2.css');
       expect(getStyleUrls()).toContain('//test/url-b-1.css');
       expect(getStyleUrls()).toContain('//test/url-b-2.css');
-      spf.net.resource.unload(css, 'b');
+      spf.net.resource.unload(CSS, 'b');
       expect(getStyleUrls()).toContain('//test/url-a-1.css');
       expect(getStyleUrls()).toContain('//test/url-a-2.css');
       expect(getStyleUrls()).not.toContain('//test/url-b-1.css');
       expect(getStyleUrls()).not.toContain('//test/url-b-2.css');
-      spf.net.resource.unload(css, 'a');
+      spf.net.resource.unload(CSS, 'a');
       expect(getStyleUrls()).not.toContain('//test/url-a-1.css');
       expect(getStyleUrls()).not.toContain('//test/url-a-2.css');
       expect(getStyleUrls()).not.toContain('//test/url-b-1.css');
@@ -377,7 +377,7 @@ describe('spf.net.resource', function() {
       spf.pubsub.subscribe('js-bar', callbacks.two);
       spf.pubsub.subscribe('js-foo|bar', callbacks.three);
       spf.pubsub.subscribe('js-other', callbacks.four);
-      spf.net.resource.check(js);
+      spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
@@ -385,41 +385,41 @@ describe('spf.net.resource', function() {
       // Not loaded.
       spf.net.resource.urls_['js-foo'] = ['//test/f1.js', '//test/f2.js'];
       spf.net.resource.urls_['js-bar'] = ['//test/b.js'];
-      spf.net.resource.check(js);
+      spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Some loading.
-      spf.net.resource.stats_['//test/b.js'] = loading;
-      spf.net.resource.check(js);
+      spf.net.resource.status_['js-//test/b.js'] = LOADING;
+      spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // All loading.
-      spf.net.resource.stats_['//test/b.js'] = loading;
-      spf.net.resource.stats_['//test/f1.js'] = loading;
-      spf.net.resource.stats_['//test/f2.js'] = loading;
-      spf.net.resource.check(js);
+      spf.net.resource.status_['js-//test/b.js'] = LOADING;
+      spf.net.resource.status_['js-//test/f1.js'] = LOADING;
+      spf.net.resource.status_['js-//test/f2.js'] = LOADING;
+      spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Some loaded, some loading.
-      spf.net.resource.stats_['//test/b.js'] = loaded;
-      spf.net.resource.stats_['//test/f1.js'] = loading;
-      spf.net.resource.stats_['//test/f2.js'] = loaded;
-      spf.net.resource.check(js);
+      spf.net.resource.status_['js-//test/b.js'] = LOADED;
+      spf.net.resource.status_['js-//test/f1.js'] = LOADING;
+      spf.net.resource.status_['js-//test/f2.js'] = LOADED;
+      spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(1);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // All loaded.
-      spf.net.resource.stats_['//test/b.js'] = loaded;
-      spf.net.resource.stats_['//test/f1.js'] = loaded;
-      spf.net.resource.stats_['//test/f2.js'] = loaded;
-      spf.net.resource.check(js);
+      spf.net.resource.status_['js-//test/b.js'] = LOADED;
+      spf.net.resource.status_['js-//test/f1.js'] = LOADED;
+      spf.net.resource.status_['js-//test/f2.js'] = LOADED;
+      spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(1);
       expect(callbacks.two.calls.length).toEqual(1);
       expect(callbacks.three.calls.length).toEqual(1);
@@ -432,7 +432,7 @@ describe('spf.net.resource', function() {
       spf.pubsub.subscribe('css-bar', callbacks.two);
       spf.pubsub.subscribe('css-foo|bar', callbacks.three);
       spf.pubsub.subscribe('css-other', callbacks.four);
-      spf.net.resource.check(css);
+      spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
@@ -440,41 +440,41 @@ describe('spf.net.resource', function() {
       // Not loaded.
       spf.net.resource.urls_['css-foo'] = ['//test/f1.css', '//test/f2.css'];
       spf.net.resource.urls_['css-bar'] = ['//test/b.css'];
-      spf.net.resource.check(css);
+      spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Some loading.
-      spf.net.resource.stats_['//test/b.css'] = loading;
-      spf.net.resource.check(css);
+      spf.net.resource.status_['css-//test/b.css'] = LOADING;
+      spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // All loading.
-      spf.net.resource.stats_['//test/b.css'] = loading;
-      spf.net.resource.stats_['//test/f1.css'] = loading;
-      spf.net.resource.stats_['//test/f2.css'] = loading;
-      spf.net.resource.check(css);
+      spf.net.resource.status_['css-//test/b.css'] = LOADING;
+      spf.net.resource.status_['css-//test/f1.css'] = LOADING;
+      spf.net.resource.status_['css-//test/f2.css'] = LOADING;
+      spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Some loaded, some loading.
-      spf.net.resource.stats_['//test/b.css'] = loaded;
-      spf.net.resource.stats_['//test/f1.css'] = loading;
-      spf.net.resource.stats_['//test/f2.css'] = loaded;
-      spf.net.resource.check(css);
+      spf.net.resource.status_['css-//test/b.css'] = LOADED;
+      spf.net.resource.status_['css-//test/f1.css'] = LOADING;
+      spf.net.resource.status_['css-//test/f2.css'] = LOADED;
+      spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(1);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // All loaded.
-      spf.net.resource.stats_['//test/b.css'] = loaded;
-      spf.net.resource.stats_['//test/f1.css'] = loaded;
-      spf.net.resource.stats_['//test/f2.css'] = loaded;
-      spf.net.resource.check(css);
+      spf.net.resource.status_['css-//test/b.css'] = LOADED;
+      spf.net.resource.status_['css-//test/f1.css'] = LOADED;
+      spf.net.resource.status_['css-//test/f2.css'] = LOADED;
+      spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(1);
       expect(callbacks.two.calls.length).toEqual(1);
       expect(callbacks.three.calls.length).toEqual(1);
@@ -487,11 +487,11 @@ describe('spf.net.resource', function() {
   describe('prefix', function() {
 
     it('adds prefixes (script)', function() {
-      expect(spf.net.resource.prefix(js, 'foo')).toEqual('js-foo');
+      expect(spf.net.resource.prefix(JS, 'foo')).toEqual('js-foo');
     });
 
     it('adds prefixes (sytle)', function() {
-      expect(spf.net.resource.prefix(css, 'foo')).toEqual('css-foo');
+      expect(spf.net.resource.prefix(CSS, 'foo')).toEqual('css-foo');
     });
 
   });
@@ -516,170 +516,170 @@ describe('spf.net.resource', function() {
   describe('canonicalize', function() {
 
     it('files (script)', function() {
-      var canonical = spf.net.resource.canonicalize(js, 'foo');
+      var canonical = spf.net.resource.canonicalize(JS, 'foo');
       expect(canonical).toEqual('//test/foo.js');
-      canonical = spf.net.resource.canonicalize(js, 'foo.js');
+      canonical = spf.net.resource.canonicalize(JS, 'foo.js');
       expect(canonical).toEqual('//test/foo.js');
-      canonical = spf.net.resource.canonicalize(js, 'foo.js.extra');
+      canonical = spf.net.resource.canonicalize(JS, 'foo.js.extra');
       expect(canonical).toEqual('//test/foo.js.extra');
       // With a path.
-      spf.net.resource.path(js, '/path/');
-      canonical = spf.net.resource.canonicalize(js, 'foo');
+      spf.net.resource.path(JS, '/path/');
+      canonical = spf.net.resource.canonicalize(JS, 'foo');
       expect(canonical).toEqual('//test/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, 'foo.js');
+      canonical = spf.net.resource.canonicalize(JS, 'foo.js');
       expect(canonical).toEqual('//test/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, 'foo.js.extra');
+      canonical = spf.net.resource.canonicalize(JS, 'foo.js.extra');
       expect(canonical).toEqual('//test/path/foo.js.extra');
       // With remapping.
-      spf.net.resource.path(js, {
+      spf.net.resource.path(JS, {
         '': 'path/',
         'foo': 'bar'
       });
-      canonical = spf.net.resource.canonicalize(js, 'foo');
+      canonical = spf.net.resource.canonicalize(JS, 'foo');
       expect(canonical).toEqual('//test/path/bar.js');
-      canonical = spf.net.resource.canonicalize(js, 'foo.js');
+      canonical = spf.net.resource.canonicalize(JS, 'foo.js');
       expect(canonical).toEqual('//test/path/bar.js');
-      canonical = spf.net.resource.canonicalize(js, 'foo.js.extra');
+      canonical = spf.net.resource.canonicalize(JS, 'foo.js.extra');
       expect(canonical).toEqual('//test/path/bar.js.extra');
     });
 
     it('files (style)', function() {
-      var canonical = spf.net.resource.canonicalize(css, 'foo');
+      var canonical = spf.net.resource.canonicalize(CSS, 'foo');
       expect(canonical).toEqual('//test/foo.css');
-      canonical = spf.net.resource.canonicalize(css, 'foo.css');
+      canonical = spf.net.resource.canonicalize(CSS, 'foo.css');
       expect(canonical).toEqual('//test/foo.css');
-      canonical = spf.net.resource.canonicalize(css, 'foo.css.extra');
+      canonical = spf.net.resource.canonicalize(CSS, 'foo.css.extra');
       expect(canonical).toEqual('//test/foo.css.extra');
       // With a path.
-      spf.net.resource.path(css, '/path/');
-      canonical = spf.net.resource.canonicalize(css, 'foo');
+      spf.net.resource.path(CSS, '/path/');
+      canonical = spf.net.resource.canonicalize(CSS, 'foo');
       expect(canonical).toEqual('//test/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, 'foo.css');
+      canonical = spf.net.resource.canonicalize(CSS, 'foo.css');
       expect(canonical).toEqual('//test/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, 'foo.css.extra');
+      canonical = spf.net.resource.canonicalize(CSS, 'foo.css.extra');
       expect(canonical).toEqual('//test/path/foo.css.extra');
       // With remapping.
-      spf.net.resource.path(css, {
+      spf.net.resource.path(CSS, {
         '': 'path/',
         'foo': 'bar'
       });
-      canonical = spf.net.resource.canonicalize(css, 'foo');
+      canonical = spf.net.resource.canonicalize(CSS, 'foo');
       expect(canonical).toEqual('//test/path/bar.css');
-      canonical = spf.net.resource.canonicalize(css, 'foo.css');
+      canonical = spf.net.resource.canonicalize(CSS, 'foo.css');
       expect(canonical).toEqual('//test/path/bar.css');
-      canonical = spf.net.resource.canonicalize(css, 'foo.css.extra');
+      canonical = spf.net.resource.canonicalize(CSS, 'foo.css.extra');
       expect(canonical).toEqual('//test/path/bar.css.extra');
     });
 
     it('relative paths (script)', function() {
-      var canonical = spf.net.resource.canonicalize(js, 'path/foo');
+      var canonical = spf.net.resource.canonicalize(JS, 'path/foo');
       expect(canonical).toEqual('//test/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, 'path/foo.js');
+      canonical = spf.net.resource.canonicalize(JS, 'path/foo.js');
       expect(canonical).toEqual('//test/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, 'path/foo.js.extra');
+      canonical = spf.net.resource.canonicalize(JS, 'path/foo.js.extra');
       expect(canonical).toEqual('//test/path/foo.js.extra');
       // With a path.
-      spf.net.resource.path(js, '/path/');
-      canonical = spf.net.resource.canonicalize(js, 'path/foo');
+      spf.net.resource.path(JS, '/path/');
+      canonical = spf.net.resource.canonicalize(JS, 'path/foo');
       expect(canonical).toEqual('//test/path/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, 'path/foo.js');
+      canonical = spf.net.resource.canonicalize(JS, 'path/foo.js');
       expect(canonical).toEqual('//test/path/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, 'path/foo.js.extra');
+      canonical = spf.net.resource.canonicalize(JS, 'path/foo.js.extra');
       expect(canonical).toEqual('//test/path/path/foo.js.extra');
       // With remapping.
-      spf.net.resource.path(js, {
+      spf.net.resource.path(JS, {
         'path/': 'longpath/',
         'foo': 'bar'
       });
-      canonical = spf.net.resource.canonicalize(js, 'path/foo');
+      canonical = spf.net.resource.canonicalize(JS, 'path/foo');
       expect(canonical).toEqual('//test/longpath/bar.js');
-      canonical = spf.net.resource.canonicalize(js, 'path/foo.js');
+      canonical = spf.net.resource.canonicalize(JS, 'path/foo.js');
       expect(canonical).toEqual('//test/longpath/bar.js');
-      canonical = spf.net.resource.canonicalize(js, 'path/foo.js.extra');
+      canonical = spf.net.resource.canonicalize(JS, 'path/foo.js.extra');
       expect(canonical).toEqual('//test/longpath/bar.js.extra');
     });
 
     it('relative paths (style)', function() {
-      var canonical = spf.net.resource.canonicalize(css, 'path/foo');
+      var canonical = spf.net.resource.canonicalize(CSS, 'path/foo');
       expect(canonical).toEqual('//test/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, 'path/foo.css');
+      canonical = spf.net.resource.canonicalize(CSS, 'path/foo.css');
       expect(canonical).toEqual('//test/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, 'path/foo.css.extra');
+      canonical = spf.net.resource.canonicalize(CSS, 'path/foo.css.extra');
       expect(canonical).toEqual('//test/path/foo.css.extra');
       // With a path.
-      spf.net.resource.path(css, '/path/');
-      canonical = spf.net.resource.canonicalize(css, 'path/foo');
+      spf.net.resource.path(CSS, '/path/');
+      canonical = spf.net.resource.canonicalize(CSS, 'path/foo');
       expect(canonical).toEqual('//test/path/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, 'path/foo.css');
+      canonical = spf.net.resource.canonicalize(CSS, 'path/foo.css');
       expect(canonical).toEqual('//test/path/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, 'path/foo.css.extra');
+      canonical = spf.net.resource.canonicalize(CSS, 'path/foo.css.extra');
       expect(canonical).toEqual('//test/path/path/foo.css.extra');
       // With remapping.
-      spf.net.resource.path(css, {
+      spf.net.resource.path(CSS, {
         'path/': 'longpath/',
         'foo': 'bar'
       });
-      canonical = spf.net.resource.canonicalize(css, 'path/foo');
+      canonical = spf.net.resource.canonicalize(CSS, 'path/foo');
       expect(canonical).toEqual('//test/longpath/bar.css');
-      canonical = spf.net.resource.canonicalize(css, 'path/foo.css');
+      canonical = spf.net.resource.canonicalize(CSS, 'path/foo.css');
       expect(canonical).toEqual('//test/longpath/bar.css');
-      canonical = spf.net.resource.canonicalize(css, 'path/foo.css.extra');
+      canonical = spf.net.resource.canonicalize(CSS, 'path/foo.css.extra');
       expect(canonical).toEqual('//test/longpath/bar.css.extra');
     });
 
     it('absolute paths (script)', function() {
-      var canonical = spf.net.resource.canonicalize(js, '/path/foo');
+      var canonical = spf.net.resource.canonicalize(JS, '/path/foo');
       expect(canonical).toEqual('//test/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, '/path/foo.js');
+      canonical = spf.net.resource.canonicalize(JS, '/path/foo.js');
       expect(canonical).toEqual('//test/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, '/path/foo.js.extra');
+      canonical = spf.net.resource.canonicalize(JS, '/path/foo.js.extra');
       expect(canonical).toEqual('//test/path/foo.js.extra');
       // With a path.
-      spf.net.resource.path(js, 'http://domain');
-      canonical = spf.net.resource.canonicalize(js, '/path/foo');
+      spf.net.resource.path(JS, 'http://domain');
+      canonical = spf.net.resource.canonicalize(JS, '/path/foo');
       expect(canonical).toEqual('http://domain/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, '/path/foo.js');
+      canonical = spf.net.resource.canonicalize(JS, '/path/foo.js');
       expect(canonical).toEqual('http://domain/path/foo.js');
-      canonical = spf.net.resource.canonicalize(js, '/path/foo.js.extra');
+      canonical = spf.net.resource.canonicalize(JS, '/path/foo.js.extra');
       expect(canonical).toEqual('http://domain/path/foo.js.extra');
       // With remapping.
-      spf.net.resource.path(js, {
+      spf.net.resource.path(JS, {
         '/path/': 'http://domain/fullpath/',
         'foo': 'bar'
       });
-      canonical = spf.net.resource.canonicalize(js, '/path/foo');
+      canonical = spf.net.resource.canonicalize(JS, '/path/foo');
       expect(canonical).toEqual('http://domain/fullpath/bar.js');
-      canonical = spf.net.resource.canonicalize(js, '/path/foo.js');
+      canonical = spf.net.resource.canonicalize(JS, '/path/foo.js');
       expect(canonical).toEqual('http://domain/fullpath/bar.js');
-      canonical = spf.net.resource.canonicalize(js, '/path/foo.js.extra');
+      canonical = spf.net.resource.canonicalize(JS, '/path/foo.js.extra');
       expect(canonical).toEqual('http://domain/fullpath/bar.js.extra');
     });
 
     it('absolute paths (style)', function() {
-      var canonical = spf.net.resource.canonicalize(css, '/path/foo');
+      var canonical = spf.net.resource.canonicalize(CSS, '/path/foo');
       expect(canonical).toEqual('//test/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, '/path/foo.css');
+      canonical = spf.net.resource.canonicalize(CSS, '/path/foo.css');
       expect(canonical).toEqual('//test/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, '/path/foo.css.extra');
+      canonical = spf.net.resource.canonicalize(CSS, '/path/foo.css.extra');
       expect(canonical).toEqual('//test/path/foo.css.extra');
       // With a path.
-      spf.net.resource.path(css, 'http://domain');
-      canonical = spf.net.resource.canonicalize(css, '/path/foo');
+      spf.net.resource.path(CSS, 'http://domain');
+      canonical = spf.net.resource.canonicalize(CSS, '/path/foo');
       expect(canonical).toEqual('http://domain/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, '/path/foo.css');
+      canonical = spf.net.resource.canonicalize(CSS, '/path/foo.css');
       expect(canonical).toEqual('http://domain/path/foo.css');
-      canonical = spf.net.resource.canonicalize(css, '/path/foo.css.extra');
+      canonical = spf.net.resource.canonicalize(CSS, '/path/foo.css.extra');
       expect(canonical).toEqual('http://domain/path/foo.css.extra');
       // With remapping.
-      spf.net.resource.path(css, {
+      spf.net.resource.path(CSS, {
         '/path/': 'http://domain/fullpath/',
         'foo': 'bar'
       });
-      canonical = spf.net.resource.canonicalize(css, '/path/foo');
+      canonical = spf.net.resource.canonicalize(CSS, '/path/foo');
       expect(canonical).toEqual('http://domain/fullpath/bar.css');
-      canonical = spf.net.resource.canonicalize(css, '/path/foo.css');
+      canonical = spf.net.resource.canonicalize(CSS, '/path/foo.css');
       expect(canonical).toEqual('http://domain/fullpath/bar.css');
-      canonical = spf.net.resource.canonicalize(css, '/path/foo.css.extra');
+      canonical = spf.net.resource.canonicalize(CSS, '/path/foo.css.extra');
       expect(canonical).toEqual('http://domain/fullpath/bar.css.extra');
     });
 
@@ -688,36 +688,36 @@ describe('spf.net.resource', function() {
       var http = 'http://domain/path/bar.js';
       var https = 'https://domain/path/bar.js';
       var local = 'file:///user/folder/bar.js';
-      var canonical = spf.net.resource.canonicalize(js, unprotocol);
+      var canonical = spf.net.resource.canonicalize(JS, unprotocol);
       expect(canonical).toEqual(unprotocol);
-      canonical = spf.net.resource.canonicalize(js, http);
+      canonical = spf.net.resource.canonicalize(JS, http);
       expect(canonical).toEqual(http);
-      canonical = spf.net.resource.canonicalize(js, https);
+      canonical = spf.net.resource.canonicalize(JS, https);
       expect(canonical).toEqual(https);
-      canonical = spf.net.resource.canonicalize(js, local);
+      canonical = spf.net.resource.canonicalize(JS, local);
       expect(canonical).toEqual(local);
       // With a path.
-      spf.net.resource.path(js, 'http://otherdomain/otherpath/');
-      canonical = spf.net.resource.canonicalize(js, unprotocol);
+      spf.net.resource.path(JS, 'http://otherdomain/otherpath/');
+      canonical = spf.net.resource.canonicalize(JS, unprotocol);
       expect(canonical).toEqual(unprotocol);
-      canonical = spf.net.resource.canonicalize(js, http);
+      canonical = spf.net.resource.canonicalize(JS, http);
       expect(canonical).toEqual(http);
-      canonical = spf.net.resource.canonicalize(js, https);
+      canonical = spf.net.resource.canonicalize(JS, https);
       expect(canonical).toEqual(https);
-      canonical = spf.net.resource.canonicalize(js, local);
+      canonical = spf.net.resource.canonicalize(JS, local);
       expect(canonical).toEqual(local);
       // With remapping.
-      spf.net.resource.path(js, {
+      spf.net.resource.path(JS, {
         '/path/': 'http://otherdomain/otherpath/',
         'bar': 'foo'
       });
-      canonical = spf.net.resource.canonicalize(js, unprotocol);
+      canonical = spf.net.resource.canonicalize(JS, unprotocol);
       expect(canonical).toEqual(unprotocol);
-      canonical = spf.net.resource.canonicalize(js, http);
+      canonical = spf.net.resource.canonicalize(JS, http);
       expect(canonical).toEqual(http);
-      canonical = spf.net.resource.canonicalize(js, https);
+      canonical = spf.net.resource.canonicalize(JS, https);
       expect(canonical).toEqual(https);
-      canonical = spf.net.resource.canonicalize(js, local);
+      canonical = spf.net.resource.canonicalize(JS, local);
       expect(canonical).toEqual(local);
     });
 
@@ -726,36 +726,36 @@ describe('spf.net.resource', function() {
       var http = 'http://domain/path/bar.css';
       var https = 'https://domain/path/bar.css';
       var local = 'file:///user/folder/bar.css';
-      var canonical = spf.net.resource.canonicalize(css, unprotocol);
+      var canonical = spf.net.resource.canonicalize(CSS, unprotocol);
       expect(canonical).toEqual(unprotocol);
-      canonical = spf.net.resource.canonicalize(css, http);
+      canonical = spf.net.resource.canonicalize(CSS, http);
       expect(canonical).toEqual(http);
-      canonical = spf.net.resource.canonicalize(css, https);
+      canonical = spf.net.resource.canonicalize(CSS, https);
       expect(canonical).toEqual(https);
-      canonical = spf.net.resource.canonicalize(css, local);
+      canonical = spf.net.resource.canonicalize(CSS, local);
       expect(canonical).toEqual(local);
       // With a path.
-      spf.net.resource.path(css, 'http://otherdomain/otherpath/');
-      canonical = spf.net.resource.canonicalize(css, unprotocol);
+      spf.net.resource.path(CSS, 'http://otherdomain/otherpath/');
+      canonical = spf.net.resource.canonicalize(CSS, unprotocol);
       expect(canonical).toEqual(unprotocol);
-      canonical = spf.net.resource.canonicalize(css, http);
+      canonical = spf.net.resource.canonicalize(CSS, http);
       expect(canonical).toEqual(http);
-      canonical = spf.net.resource.canonicalize(css, https);
+      canonical = spf.net.resource.canonicalize(CSS, https);
       expect(canonical).toEqual(https);
-      canonical = spf.net.resource.canonicalize(css, local);
+      canonical = spf.net.resource.canonicalize(CSS, local);
       expect(canonical).toEqual(local);
       // With remapping.
-      spf.net.resource.path(css, {
+      spf.net.resource.path(CSS, {
         '/path/': 'http://otherdomain/otherpath/',
         'bar': 'foo'
       });
-      canonical = spf.net.resource.canonicalize(css, unprotocol);
+      canonical = spf.net.resource.canonicalize(CSS, unprotocol);
       expect(canonical).toEqual(unprotocol);
-      canonical = spf.net.resource.canonicalize(css, http);
+      canonical = spf.net.resource.canonicalize(CSS, http);
       expect(canonical).toEqual(http);
-      canonical = spf.net.resource.canonicalize(css, https);
+      canonical = spf.net.resource.canonicalize(CSS, https);
       expect(canonical).toEqual(https);
-      canonical = spf.net.resource.canonicalize(css, local);
+      canonical = spf.net.resource.canonicalize(CSS, local);
       expect(canonical).toEqual(local);
     });
 

--- a/src/client/net/script_test.js
+++ b/src/client/net/script_test.js
@@ -17,7 +17,7 @@ goog.require('spf.url');
 
 describe('spf.net.script', function() {
 
-  var js = spf.net.resource.Type.JS;
+  var JS = spf.net.resource.Type.JS;
   var nodes;
   var callbacks;
   var fakes = {
@@ -34,7 +34,7 @@ describe('spf.net.script', function() {
     },
     resource: {
       create: function(type, url, opt_callback, opt_document) {
-        url = spf.net.resource.canonicalize(js, url);
+        url = spf.net.resource.canonicalize(JS, url);
         var el = {
           setAttribute: function(n, v) {
             el[n] = v;
@@ -46,7 +46,8 @@ describe('spf.net.script', function() {
         el.src = url;
         el.className = type + '-' + url.replace(/[^\w]/g, '');
         nodes.push(el);
-        spf.net.resource.stats_[url] = spf.net.resource.Status.LOADED;
+        var key = type + '-' + url;
+        spf.net.resource.status_[key] = spf.net.resource.State.LOADED;
         opt_callback && opt_callback();
         return el;
       },
@@ -60,7 +61,8 @@ describe('spf.net.script', function() {
           return true;
         });
         nodes.splice(idx, 1);
-        delete spf.net.resource.stats_[url];
+        var key = type + '-' + url;
+        delete spf.net.resource.status_[key];
       }
     }
   };
@@ -75,7 +77,7 @@ describe('spf.net.script', function() {
     spf.net.script.urls_ = {};
     spf.net.script.deps_ = {};
     spf.net.resource.urls_ = {};
-    spf.net.resource.stats_ = {};
+    spf.net.resource.status_ = {};
 
     nodes = [];
     callbacks = {
@@ -105,7 +107,7 @@ describe('spf.net.script', function() {
       var url = 'url-a.js';
       spf.net.script.load(url);
       expect(spf.net.resource.load).toHaveBeenCalledWith(
-          js, url, undefined, undefined);
+          JS, url, undefined, undefined);
     });
 
     it('passes a single url with name', function() {
@@ -113,31 +115,31 @@ describe('spf.net.script', function() {
       var name = 'a';
       spf.net.script.load(url, name);
       expect(spf.net.resource.load).toHaveBeenCalledWith(
-          js, url, name, undefined);
+          JS, url, name, undefined);
     });
 
-    it('passes a single url with function', function() {
+    it('passes a single url with callback', function() {
       var url = 'url-a.js';
       var fn = function() {};
       spf.net.script.load(url, fn);
       expect(spf.net.resource.load).toHaveBeenCalledWith(
-          js, url, fn, undefined);
+          JS, url, fn, undefined);
     });
 
-    it('passes a single url with name function', function() {
+    it('passes a single url with name and callback', function() {
       var url = 'url-a.js';
       var name = 'a';
       var fn = function() {};
       spf.net.script.load(url, name, fn);
       expect(spf.net.resource.load).toHaveBeenCalledWith(
-          js, url, name, fn);
+          JS, url, name, fn);
     });
 
     it('passes multiple urls', function() {
       var urls = ['url-a-1.js', 'url-a-2.js'];
       spf.net.script.load(urls);
       expect(spf.net.resource.load).toHaveBeenCalledWith(
-          js, urls, undefined, undefined);
+          JS, urls, undefined, undefined);
     });
 
     it('passes multiple urls with name', function() {
@@ -145,24 +147,24 @@ describe('spf.net.script', function() {
       var name = 'a';
       spf.net.script.load(urls, name);
       expect(spf.net.resource.load).toHaveBeenCalledWith(
-          js, urls, name, undefined);
+          JS, urls, name, undefined);
     });
 
-    it('passes multiple urls with function', function() {
+    it('passes multiple urls with callback', function() {
       var urls = ['url-a-1.js', 'url-a-2.js'];
       var fn = function() {};
       spf.net.script.load(urls, fn);
       expect(spf.net.resource.load).toHaveBeenCalledWith(
-          js, urls, fn, undefined);
+          JS, urls, fn, undefined);
     });
 
-    it('passes multiple urls with name function', function() {
+    it('passes multiple urls with name and callback', function() {
       var urls = ['url-a-1.js', 'url-a-2.js'];
       var name = 'a';
       var fn = function() {};
       spf.net.script.load(urls, name, fn);
       expect(spf.net.resource.load).toHaveBeenCalledWith(
-          js, urls, name, fn);
+          JS, urls, name, fn);
     });
 
   });
@@ -173,7 +175,7 @@ describe('spf.net.script', function() {
     it('passes name', function() {
       var name = 'a';
       spf.net.script.unload(name);
-      expect(spf.net.resource.unload).toHaveBeenCalledWith(js, name);
+      expect(spf.net.resource.unload).toHaveBeenCalledWith(JS, name);
     });
 
   });
@@ -185,7 +187,7 @@ describe('spf.net.script', function() {
       var url = 'url-a.js';
       spf.net.script.get(url);
       expect(spf.net.resource.create).toHaveBeenCalledWith(
-          js, url, undefined);
+          JS, url, undefined);
     });
 
     it('passes url with function', function() {
@@ -193,7 +195,7 @@ describe('spf.net.script', function() {
       var fn = function() {};
       spf.net.script.get(url, fn);
       expect(spf.net.resource.create).toHaveBeenCalledWith(
-          js, url, fn);
+          JS, url, fn);
     });
 
   });
@@ -205,7 +207,7 @@ describe('spf.net.script', function() {
       var url = 'url-a.js';
       spf.net.script.prefetch(url);
       expect(spf.net.resource.prefetch).toHaveBeenCalledWith(
-          js, url);
+          JS, url);
     });
 
     it('calls for multiples urls', function() {
@@ -213,7 +215,7 @@ describe('spf.net.script', function() {
       spf.net.script.prefetch(urls);
       spf.array.each(urls, function(url) {
         expect(spf.net.resource.prefetch).toHaveBeenCalledWith(
-            js, url);
+            JS, url);
       });
     });
 
@@ -454,37 +456,37 @@ describe('spf.net.script', function() {
   });
 
 
-  describe('eval', function() {
+  describe('exec', function() {
 
     it('standard', function() {
-      expect(function() { spf.net.script.eval(''); }).not.toThrow();
+      expect(function() { spf.net.script.exec(''); }).not.toThrow();
       var text = 'var _global_1_ = 1;';
-      spf.net.script.eval(text);
+      spf.net.script.exec(text);
       expect(window['_global_1_']).toEqual(1);
     });
 
     it('strict', function() {
       var text = '"use strict";' +
           'var _global_2_ = 2;';
-      spf.net.script.eval(text);
+      spf.net.script.exec(text);
       expect(window['_global_2_']).toEqual(2);
     });
 
     it('recursive standard', function() {
       text = 'var _global_3_ = 3;' +
-          'spf.net.script.eval("var _global_4_ = 4;");';
-      spf.net.script.eval(text);
+          'spf.net.script.exec("var _global_4_ = 4;");';
+      spf.net.script.exec(text);
       expect(window['_global_3_']).toEqual(3);
       expect(window['_global_4_']).toEqual(4);
     });
 
     it('recursive mixed', function() {
       text = 'var _global_5_ = 5;' +
-          'spf.net.script.eval("' +
+          'spf.net.script.exec("' +
           "'use strict';" +
           'var _global_6_ = 6;' +
           '");';
-      spf.net.script.eval(text);
+      spf.net.script.exec(text);
       expect(window['_global_5_']).toEqual(5);
       expect(window['_global_6_']).toEqual(6);
     });
@@ -492,11 +494,11 @@ describe('spf.net.script', function() {
     it('recursive strict', function() {
       text = '"use strict";' +
           'var _global_7_ = 7;' +
-          'spf.net.script.eval("' +
+          'spf.net.script.exec("' +
           "'use strict';" +
           'var _global_8_ = 8;' +
           '");';
-      spf.net.script.eval(text);
+      spf.net.script.exec(text);
       expect(window['_global_7_']).toEqual(7);
       expect(window['_global_8_']).toEqual(8);
     });

--- a/src/client/net/style.js
+++ b/src/client/net/style.js
@@ -23,23 +23,24 @@ goog.require('spf.tracing');
  * remove previously loaded styles.
  *
  * - Subsequent calls to load the same URL will not reload the style.  To
- *   reload a style, unload it first with {@link #unload}.
- *
- * - A callback can be specified to execute once the style has loaded.  The
- *   callback will be executed each time, even if the style is not reloaded.
- *   NOTE: Unlike scripts, this callback is best effort and is supported
- *   in the following browser versions: IE 6, Chrome 19, Firefox 9, Safari 6.
+ *   reload a style, unload it first with {@link #unload}.  To unconditionally
+ *   load a style, see {@link #get}.
  *
  * - A name can be specified to identify the same style at different URLs.
  *   (For example, "main-A.css" and "main-B.css" are both "main".)  If a name
  *   is specified, all other styles with the same name will be unloaded.
  *   This allows switching between versions of the same style at different URLs.
  *
+ * - A callback can be specified to execute once the style has loaded.  The
+ *   callback will be executed each time, even if the style is not reloaded.
+ *   NOTE: Unlike scripts, this callback is best effort and is supported
+ *   in the following browser versions: IE 6, Chrome 19, Firefox 9, Safari 6.
+ *
  * @param {string|Array.<string>} urls One or more URLs of styles to load.
- * @param {(string|Function)=} opt_nameOrFn Name to identify the style(s)
- *     or callback function to execute when the style is loaded.
- * @param {Function=} opt_fn Callback function to execute when the style is
- *     loaded.
+ * @param {(string|Function)=} opt_nameOrFn Name to identify the styles
+ *     or callback function to execute when the styles are loaded.
+ * @param {Function=} opt_fn Optional callback function to execute when the
+ *     styles are loaded.
  */
 spf.net.style.load = function(urls, opt_nameOrFn, opt_fn) {
   var type = spf.net.resource.Type.CSS;
@@ -75,13 +76,12 @@ spf.net.style.discover = function() {
  *
  * @param {string} url The URL of the style to load.
  * @param {Function=} opt_fn Function to execute when loaded.
- * @return {Element} The newly created element.
  */
 spf.net.style.get = function(url, opt_fn) {
   // NOTE: Callback execution depends on onload support and is best effort.
   // Chrome 19, Safari 6, Firefox 9, Opera and IE 5.5 support stylesheet onload.
   var type = spf.net.resource.Type.CSS;
-  return spf.net.resource.create(type, url, opt_fn);
+  spf.net.resource.create(type, url, opt_fn);
 };
 
 
@@ -103,27 +103,29 @@ spf.net.style.prefetch = function(urls) {
 
 
 /**
- * Evaluates a set of styles by dynamically creating an element and appending it
- * to the document.  A callback can be specified to execute once evaluation
- * is done.
+ * Evaluates style text and defines a name to use for management.
+ *
+ * - Subsequent calls to evaluate the same text will not re-evaluate the style.
+ *   To unconditionally evalute a style, see {@link #exec}.
  *
  * @param {string} text The text of the style.
+ * @param {string} name Name to identify the style.
  * @return {undefined}
  */
-spf.net.style.eval = function(text) {
-  text = spf.string.trim(text);
-  if (text) {
-    var styleEl = document.createElement('style');
-    var targetEl = document.getElementsByTagName('head')[0] || document.body;
-    // IE requires the Style element to be in the document before accessing
-    // the StyleSheet object.
-    targetEl.appendChild(styleEl);
-    if ('styleSheet' in styleEl) {
-      styleEl.styleSheet.cssText = text;
-    } else {
-      styleEl.appendChild(document.createTextNode(text));
-    }
-  }
+spf.net.style.eval = function(text, name) {
+  var type = spf.net.resource.Type.CSS;
+  spf.net.resource.eval(type, text, name);
+};
+
+
+/**
+ * Unconditionally evaluates style text.  See {@link #eval}.
+ *
+ * @param {string} text The text of the style.
+ */
+spf.net.style.exec = function(text) {
+  var type = spf.net.resource.Type.CSS;
+  spf.net.resource.exec(type, text);
 };
 
 

--- a/src/client/net/style_test.js
+++ b/src/client/net/style_test.js
@@ -41,7 +41,7 @@ describe('spf.net.style', function() {
           css, url, name, undefined);
     });
 
-    it('passes a single url with function', function() {
+    it('passes a single url with callback', function() {
       var url = 'url-a.css';
       var fn = function() {};
       spf.net.style.load(url, fn);
@@ -49,7 +49,7 @@ describe('spf.net.style', function() {
           css, url, fn, undefined);
     });
 
-    it('passes a single url with name function', function() {
+    it('passes a single url with name and callback', function() {
       var url = 'url-a.css';
       var name = 'a';
       var fn = function() {};
@@ -73,7 +73,7 @@ describe('spf.net.style', function() {
           css, urls, name, undefined);
     });
 
-    it('passes multiple urls with function', function() {
+    it('passes multiple urls with callback', function() {
       var urls = ['url-a-1.css', 'url-a-2.css'];
       var fn = function() {};
       spf.net.style.load(urls, fn);
@@ -81,7 +81,7 @@ describe('spf.net.style', function() {
           css, urls, fn, undefined);
     });
 
-    it('passes multiple urls with name function', function() {
+    it('passes multiple urls with name and callback', function() {
       var urls = ['url-a-1.css', 'url-a-2.css'];
       var name = 'a';
       var fn = function() {};

--- a/src/client/pubsub/pubsub.js
+++ b/src/client/pubsub/pubsub.js
@@ -22,9 +22,11 @@ goog.require('spf.state');
  * scope.  Subscribing the same function to the same topic multiple
  * times will result in multiple function invocations while publishing.
  *
- * @param {string} topic Topic to subscribe to.
- * @param {Function} fn Function to be invoked when a message is published
- *     to the given topic.
+ * @param {string} topic Topic to subscribe to. Passing an empty string does
+ *     nothing.
+ * @param {Function|undefined} fn Function to be invoked when a message is
+ *     published to the given topic. Passing {@code null} or {@code undefined}
+ *     does nothing.
  */
 spf.pubsub.subscribe = function(topic, fn) {
   if (topic && fn) {
@@ -37,10 +39,12 @@ spf.pubsub.subscribe = function(topic, fn) {
 
 
 /**
- * Unsubscribes a function from a topic.  Only deletes the first match found.
+ * Unsubscribes a function from a topic. Only deletes the first match found.
  *
- * @param {string} topic Topic to unsubscribe from.
- * @param {Function} fn Function to unsubscribe.
+ * @param {string} topic Topic to unsubscribe from. Passing an empty string does
+ *     nothing.
+ * @param {Function|undefined} fn Function to unsubscribe. Passing {@code null}
+ *     or {@code undefined} does nothing.
  */
 spf.pubsub.unsubscribe = function(topic, fn) {
   if (topic in spf.pubsub.subscriptions && fn) {
@@ -60,7 +64,8 @@ spf.pubsub.unsubscribe = function(topic, fn) {
  * the order in which they were added.  If any of the functions throws an
  * uncaught error, publishing is aborted.
  *
- * @param {string} topic Topic to publish.
+ * @param {string} topic Topic to publish. Passing an empty string does
+ *     nothing.
  */
 spf.pubsub.publish = function(topic) {
   spf.pubsub.publish_(topic);
@@ -73,7 +78,8 @@ spf.pubsub.publish = function(topic) {
  * If any of the functions throws an uncaught error, publishing is aborted.
  * See {#publish} and {#clear}.
  *
- * @param {string} topic Topic to publish.
+ * @param {string} topic Topic to publish. Passing an empty string does
+ *     nothing.
  */
 spf.pubsub.flush = function(topic) {
   spf.pubsub.publish_(topic, true);

--- a/src/client/state.js
+++ b/src/client/state.js
@@ -75,7 +75,7 @@ spf.state.Key = {
   PREFETCH_LISTENER: 'prefetch-listener',
   PUBSUB_SUBS: 'ps-s',
   RESOURCE_PATHS_PREFIX: 'rsrc-p-',
-  RESOURCE_STATS: 'rsrc-s',
+  RESOURCE_STATUS: 'rsrc-s',
   RESOURCE_URLS: 'rsrc-u',
   SCRIPT_DEPS: 'js-d',
   SCRIPT_URLS: 'js-u',

--- a/src/server/demo/templates/chunked.tmpl
+++ b/src/server/demo/templates/chunked.tmpl
@@ -5,7 +5,7 @@ $# See the LICENSE file for details.
 
 $def _stylesheet():
   <!-- This style is inlined here for demo purposes. -->
-  <style type="text/css">
+  <style name="chunked">
     #chunked-actions p { float: left;
                          width: 44%; height: 4em;
                          margin: 1em; padding: 1em;
@@ -21,7 +21,7 @@ $def _attributes():
   { "nav": { "class": "test" } }
 
 $def _javascript():
-  <script src="/static/app-chunked.js"></script>
+  <script src="/static/app-chunked.js" name="chunked"></script>
 
 
 $var title: Chunked Test

--- a/src/server/demo/templates/demo.tmpl
+++ b/src/server/demo/templates/demo.tmpl
@@ -8,7 +8,7 @@ $# See the LICENSE file for details.
 
 $def _stylesheet():
   <!-- This style is inlined here for demo purposes. -->
-  <style type="text/css">
+  <style name="demo-inline">
     .demo p { float: left;
               width: 44%; height: 9em;
               margin: 1em; padding: 1em;
@@ -20,7 +20,7 @@ $def _stylesheet():
     .demo .sun img { height: 3em;
                      vertical-align: middle; }
   </style>
-  <link rel="stylesheet" href="/static/app-demo.css">
+  <link rel="stylesheet" href="/static/app-demo.css" name="demo-external">
 
 $def _attributes():
   { "nav": { "class": "demo$page_num" } }
@@ -33,7 +33,7 @@ $var attributes: $:_attributes()
 <div id="demo" class="pane demo">
   <h1>Demo Page $page_num</h1>
   <!-- Demonstrate scripts in the middle of a content fragment -->
-  <script src="/static/app-demo.js"></script>
+  <script src="/static/app-demo.js" name="demo"></script>
   <script>
     app.log('demo $page_num: embedded javascript')
     app.log('external js is loaded = ' + !!(window.app && app.demo && app.demo.loaded));

--- a/src/server/demo/templates/index.tmpl
+++ b/src/server/demo/templates/index.tmpl
@@ -4,7 +4,7 @@ $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.
 
 $def _stylesheet():
-  <style type="text/css">
+  <style name="home">
     #home .col {
       width: 50%;
       float: left;

--- a/src/server/demo/templates/index_ajax.tmpl
+++ b/src/server/demo/templates/index_ajax.tmpl
@@ -4,7 +4,7 @@ $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.
 
 $def _stylesheet():
-  <style type="text/css">
+  <style name="home-ajax">
     #home .lucky-num {
       font-weight: bold;
     }

--- a/src/server/demo/templates/spec.tmpl
+++ b/src/server/demo/templates/spec.tmpl
@@ -4,7 +4,7 @@ $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.
 
 $def _stylesheet():
-  <style type="text/css">
+  <style name="spec">
     #spec pre em { background: #DDD; }
   </style>
 


### PR DESCRIPTION
Split inline script and style evaluation into two functions:
- `eval`: conditionally evaluate the text only if changed
- `exec`: unconditionally execute the text

This matches the behavior of external script and style installation:
- `load`: conditionally install the resource only if changed
- `get`: unconditionally install the resource.

For now, guard the new logic behind a `experimental-execute-unified` config.

Progress on #25.
