### PR TITLE
Prevent attempted cross-domain navigation (experimental).

### DIFF
--- a/src/client/nav/nav_test.js
+++ b/src/client/nav/nav_test.js
@@ -299,11 +299,11 @@ describe('spf.nav', function() {
       spyOn(spf.nav, 'getAncestorWithHref_').andCallFake(function() {
           return {href: evt.target.href}; });
       spyOn(spf.nav, 'getAncestorWithLinkClass_').andCallFake(objFunc);
-      spyOn(spf.nav, 'isNavigateEligible_').andCallFake(falseFunc);
+      spyOn(spf.nav, 'isEligible_').andCallFake(falseFunc);
 
       spf.nav.handleClick_(evt);
 
-      expect(spf.nav.isNavigateEligible_).toHaveBeenCalled();
+      expect(spf.nav.isEligible_).toHaveBeenCalled();
       expect(evt.defaultPrevented).toEqual(false);
       expect(spf.nav.navigate_).not.toHaveBeenCalled();
     });
@@ -325,15 +325,29 @@ describe('spf.nav', function() {
   });
 
 
-  describe('isNavigateEligible', function() {
+  describe('isAllowed', function() {
+
+
+    it('respects same-origin security', function() {
+      var sameDomainUrl = '/page';
+      var crossDomainUrl = 'https://www.google.com/';
+      expect(spf.nav.isAllowed_(sameDomainUrl)).toBe(true);
+      expect(spf.nav.isAllowed_(crossDomainUrl)).toBe(false);
+    });
+
+
+  });
+
+
+  describe('isEligible', function() {
 
 
     it('respects initialization', function() {
       var url = '/page';
       spf.state.set(spf.state.Key.NAV_INIT, false);
-      expect(spf.nav.isNavigateEligible_(url)).toBe(false);
+      expect(spf.nav.isEligible_(url)).toBe(false);
       spf.state.set(spf.state.Key.NAV_INIT, true);
-      expect(spf.nav.isNavigateEligible_(url)).toBe(true);
+      expect(spf.nav.isEligible_(url)).toBe(true);
     });
 
 
@@ -341,12 +355,12 @@ describe('spf.nav', function() {
       var url = '/page';
       spf.config.set('navigate-limit', 5);
       spf.state.set(spf.state.Key.NAV_COUNTER, 5);
-      expect(spf.nav.isNavigateEligible_(url)).toBe(false);
+      expect(spf.nav.isEligible_(url)).toBe(false);
       spf.state.set(spf.state.Key.NAV_COUNTER, 4);
-      expect(spf.nav.isNavigateEligible_(url)).toBe(true);
+      expect(spf.nav.isEligible_(url)).toBe(true);
       spf.config.set('navigate-limit', null);
       spf.state.set(spf.state.Key.NAV_COUNTER, 999999);
-      expect(spf.nav.isNavigateEligible_(url)).toBe(true);
+      expect(spf.nav.isEligible_(url)).toBe(true);
     });
 
 
@@ -354,12 +368,12 @@ describe('spf.nav', function() {
       var url = '/page';
       spf.config.set('navigate-lifetime', 1000);
       spf.state.set(spf.state.Key.NAV_TIME, spf.now() - 1000);
-      expect(spf.nav.isNavigateEligible_(url)).toBe(false);
+      expect(spf.nav.isEligible_(url)).toBe(false);
       spf.state.set(spf.state.Key.NAV_TIME, spf.now() - 500);
-      expect(spf.nav.isNavigateEligible_(url)).toBe(true);
+      expect(spf.nav.isEligible_(url)).toBe(true);
       spf.config.set('navigate-lifetime', null);
       spf.state.set(spf.state.Key.NAV_TIME, spf.now() - (10 * 24 * 60 * 60 * 1000));
-      expect(spf.nav.isNavigateEligible_(url)).toBe(true);
+      expect(spf.nav.isEligible_(url)).toBe(true);
     });
 
 

--- a/src/client/url/url.js
+++ b/src/client/url/url.js
@@ -15,6 +15,60 @@ goog.require('spf.config');
 goog.require('spf.string');
 
 
+
+/**
+ * See {@link https://developer.mozilla.org/en-US/docs/Web/API/URLUtils}.
+ *
+ * @typedef {{
+ *   href: string,
+ *   protocol: string,
+ *   host: string,
+ *   hostname: string,
+ *   port: string,
+ *   pathname: string,
+ *   search: string,
+ *   hash: string,
+ *   username: string,
+ *   password: string,
+ *   origin: string
+ * }}
+ */
+spf.url.URLUtils;
+
+
+/**
+ * Returns a URLUtils compatible object for a given url. For the interface, see
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/URLUtils}.
+ *
+ * @param {string} url A relative or absolute URL.
+ * @return {spf.url.URLUtils} The URLUtils object.
+ */
+spf.url.utils = function(url) {
+  var aEl = document.createElement('a');
+  aEl.href = url;
+  var utils = {
+    href: aEl.href,
+    protocol: aEl.protocol,
+    host: aEl.host,
+    hostname: aEl.hostname,
+    port: aEl.port,
+    pathname: aEl.pathname,
+    search: aEl.search,
+    hash: aEl.hash,
+    username: aEl.username,
+    password: aEl.password
+  };
+  // The origin is the combination of scheme, domain, and port.
+  utils.origin = utils.protocol + '//' + utils.host;
+  // IE does not include the leading slash on a path. So if the path is
+  // available, but no leading slash is present, prepend one.
+  if (!utils.pathname || utils.pathname[0] != '/') {
+    utils.pathname = '/' + utils.pathname;
+  }
+  return utils;
+};
+
+
 /**
  * Converts a relative URL to absolute based on the current document domain.
  * Also removes the fragment from the URL, if one exists.
@@ -23,29 +77,32 @@ goog.require('spf.string');
  * @return {string} An absolute URL (with fragment removed, if possible).
  */
 spf.url.absolute = function(relative) {
-  var aEl = document.createElement('a');
-  aEl.href = relative;
-  return spf.url.unfragment(aEl.href);
+  var utils = spf.url.utils(relative);
+  return spf.url.unfragment(utils.href);
 };
 
 
 /**
- * Returns just the path portion of a given URL, relative or absolute.
+ * Returns the path portion of a given URL.
  *
- * @param {string} url The full URL.
+ * @param {string} url A relative or absolute URL.
  * @return {string} The path portion of the URL.
  */
 spf.url.path = function(url) {
-  var aEl = document.createElement('a');
-  aEl.href = url;
-  var path = aEl.pathname;
-  // IE does not include the leading slash on a path. So if the path is
-  // available, but no leading slash is present, prepend one.
-  if (!!path && path[0] == '/') {
-    return path;
-  } else {
-    return '/' + path;
-  }
+  var utils = spf.url.utils(url);
+  return utils.pathname;
+};
+
+
+/**
+ * Returns the origin of a given URL (scheme + domain + port).
+ *
+ * @param {string} url A relative or absolute URL.
+ * @return {string} The origin of the URL.
+ */
+spf.url.origin = function(url) {
+  var utils = spf.url.utils(url);
+  return utils.origin;
 };
 
 


### PR DESCRIPTION
For now, guard the new logic behind a `experimental-same-origin` config.

Progress on #30.
