### PR TITLE
Treat compilation warnings as errors.

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -191,6 +191,41 @@ def write_variables(ninja):
       '--define "SPF_DEBUG=false"',
       '--summary_detail_level 3',
       '--warning_level VERBOSE',
+      '--jscomp_error accessControls',
+      '--jscomp_error ambiguousFunctionDecl',
+      '--jscomp_error checkEventfulObjectDisposal',
+      '--jscomp_error checkRegExp',
+      '--jscomp_error checkStructDictInheritance',
+      '--jscomp_error checkTypes',
+      '--jscomp_error checkVars',
+      '--jscomp_error const',
+      '--jscomp_error constantProperty',
+      '--jscomp_error deprecated',
+      '--jscomp_error duplicateMessage',
+      '--jscomp_error es3',
+      '--jscomp_error es5Strict',
+      '--jscomp_error externsValidation',
+      '--jscomp_error fileoverviewTags',
+      '--jscomp_error globalThis',
+      '--jscomp_error internetExplorerChecks',
+      '--jscomp_error invalidCasts',
+      '--jscomp_error misplacedTypeAnnotation',
+      '--jscomp_error missingGetCssName',
+      '--jscomp_error missingProperties',
+      '--jscomp_error missingProvide',
+      '--jscomp_error missingRequire',
+      '--jscomp_error missingReturn',
+      '--jscomp_error newCheckTypes',
+      '--jscomp_error nonStandardJsDocs',
+      '--jscomp_error suspiciousCode',
+      '--jscomp_error strictModuleDepCheck',
+      '--jscomp_error typeInvalidation',
+      '--jscomp_error undefinedNames',
+      '--jscomp_error undefinedVars',
+      '--jscomp_error unknownDefines',
+      '--jscomp_error uselessCode',
+      '--jscomp_error useOfGoogBase',
+      '--jscomp_error visibility',
   ]
   debug_jsflags = common_jsflags + [
       '--debug true',
@@ -230,7 +265,7 @@ def write_rules(ninja):
              command='$license > $out '
                      '&& $preamble >> $out '
                      '&& java -jar $jscompiler_jar $flags $in >> $out '
-                     '|| rm $out',
+                     '|| (rm $out; false)',
              description='jscompile $out')
 
   ninja.newline()


### PR DESCRIPTION
When compiling for production, treat all warnings as errors.  The only class of
warnings ignored is "reportUnknownTypes", which currently reports many false
positives.  Also, ensure failed compilation processes exit with a non-zero
status code on the command line.
