### PR TITLE
Add support for reloading the page with a response attribute.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -68,12 +68,18 @@ spf.SingleResponse.prototype.head;
 spf.SingleResponse.prototype.foot;
 
 
-
 /**
  * String of a URL to request instead.
  * @type {string|undefined}
  */
 spf.SingleResponse.prototype.redirect;
+
+
+/**
+ * Boolean to indicate the page should be reloaded.
+ * @type {boolean|undefined}
+ */
+spf.SingleResponse.prototype.reload;
 
 
 /**

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -147,6 +147,7 @@ spf.EventName = {
  * - foot: HTML string containing <script> tags of JS to execute.
  * - head: HTML string containing <link> and <style> tags of CSS to install.
  * - redirect: String of a URL to request instead.
+ * - reload: Boolean to indicate the page should be reloaded.
  * - timing: Map of timing attributes to timestamp numbers.
  * - title: String of the new Document title.
  * - url: String of the correct URL for the current request. This will replace
@@ -159,6 +160,7 @@ spf.EventName = {
  *   foot: (string|undefined),
  *   head: (string|undefined),
  *   redirect: (string|undefined),
+ *   reload: (boolean|undefined),
  *   timing: (Object.<string, number>|undefined),
  *   title: (string|undefined),
  *   url: (string|undefined)


### PR DESCRIPTION
Now, a response with the `reload` attribute will trigger a reload.  The
attribute value should be a boolean, as follows:

``` json
{
  "reload": true
}
```

Closes #103.
