### PR TITLE
Ensure the spf.process API function works.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -389,14 +389,15 @@ spf.load = function(url, opt_options) {};
 
 
 /**
- * Process a response using the SPF protocol.
- *
- * @deprecated Use spf.load instead.
+ * Process a SPF response on the current page outside of a navigation flow.
  *
  * @param {spf.SingleResponse|spf.MultipartResponse} response The SPF response
  *     object to process.
+ * @param {function(spf.SingleResponse|spf.MultipartResponse)=} opt_callback
+ *     Function to execute when processing is done; the argument is
+ *     the {@code response}.
  */
-spf.process = function(response) {};
+spf.process = function(response, opt_callback) {};
 
 
 /**

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -104,8 +104,8 @@ spf.main.api_ = {
   'dispose': spf.main.dispose,
   'navigate': spf.nav.navigate,
   'load': spf.nav.load,
-  'process': spf.nav.response.process,  // TODO: Remove after deprecation.
-  'prefetch': spf.nav.prefetch
+  'prefetch': spf.nav.prefetch,
+  'process': spf.nav.process
 };
 /** @private {!Object} */
 spf.main.extra_ = {

--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -1126,6 +1126,37 @@ spf.nav.handleLoadRedirect_ = function(isPrefetch, options, original,
 
 
 /**
+ * Process a SPF response on the current page outside of a navigation flow.
+ *
+ * @param {spf.SingleResponse|spf.MultipartResponse} response The SPF response
+ *     object to process.
+ * @param {function((spf.SingleResponse|spf.MultipartResponse))=} opt_callback
+ *     Function to execute when processing is done; the argument is
+ *     the {@code response}.
+ */
+spf.nav.process = function(response, opt_callback) {
+  var url = window.location.href;
+  var multipart = response['type'] == 'multipart';
+  var done = function(index, max, _, resp) {
+    if (index == max && opt_callback) {
+      opt_callback(resp);
+    }
+  };
+  if (multipart) {
+    var parts = response['parts'];
+    for (var i = 0; i < parts.length; i++) {
+      var fn = spf.bind(done, null, i, parts.length - 1);
+      spf.nav.response.process(url, parts[i], fn);
+    }
+  } else {
+    response = /** @type {spf.SingleResponse} */ (response);
+    var fn = spf.bind(done, null, 0, 0);
+    spf.nav.response.process(url, response, fn);
+  }
+};
+
+
+/**
  * Dispatches the "error" event with the following custom event detail:
  *   url: The current URL.
  *   err: The Error object.


### PR DESCRIPTION
Add a dedicated function to process a SPF response on the current page outside
of a navigation flow.  Export it as the `spf.process` function.

Closes #108.
