### PR TITLE
Allow advanced users to enable request identification via header.

### DIFF
--- a/src/client/net/xhr.js
+++ b/src/client/net/xhr.js
@@ -11,6 +11,8 @@
 
 goog.provide('spf.net.xhr');
 
+goog.require('spf');
+
 
 /**
  * Type definition for the configuration options for an XMLHttpRequest.


### PR DESCRIPTION
Add support for sending an HTTP header to identify requests.  This provides an
alternate system for negotiation between SPF and default browser requests, but
it adds a restriction on developers: a `Vary` header MUST be returned by the
server to avoid caching problems.  Guard this behavior behind an "advanced"
config flag and provide no default to prevent accidental usage.

A normal SPF request looks like

```
GET /path?spf=navigate
```

By setting `url-identifier` to `null` and `advanced-header-identifier` to
`__type__`, a SPF request would then look like

```
GET /path
Accept: application/json
X-SPF-Request: navigate
```

And the server must then return

```
Vary: Accept
```

Closes #31.
