### PR TITLE
Add cache.remove and cache.clear as external APIs.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -41,6 +41,13 @@ spf.SingleResponse.prototype.body;
 
 
 /**
+ * String of the cache key used to store this response.
+ * @type {string|undefined}
+ */
+spf.SingleResponse.prototype.cacheKey;
+
+
+/**
  * String of the type of caching to use for this response.
  * @type {string|undefined}
  */
@@ -103,6 +110,13 @@ spf.SingleResponse.prototype.url;
  * @interface
  */
 spf.MultipartResponse;
+
+
+/**
+ * String of the key used to cache this response.
+ * @type {string|undefined}
+ */
+spf.MultipartResponse.prototype.cacheKey;
 
 
 /**
@@ -410,6 +424,32 @@ spf.process = function(response) {};
  * @return {XMLHttpRequest} The XHR of the current request.
  */
 spf.prefetch = function(url, opt_options) {};
+
+
+/**
+ * Namespace for cache handling functions.
+ */
+spf.cache = {};
+
+
+/**
+ * Removes an entry from cache.
+ *
+ * Removed entries will be completely removed from cache, affecting both normal
+ * navigations as well as those triggered by a history change.
+ *
+ * @param {string} key The key to remove from cache.
+ */
+spf.cache.remove = function(key) {};
+
+
+/**
+ * Clear all entries from cache.
+ *
+ * Removed entries will be completely removed from cache, affecting both normal
+ * navigations as well as those triggered by a history change.
+ */
+spf.cache.clear = function() {};
 
 
 /**

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -143,6 +143,7 @@ spf.EventName = {
  *      to set on the Elements.
  * - body: Map of Element IDs to HTML strings containing content with which
  *      to update the Elements.
+ * - cacheKey: Key used to cache this response.
  * - cacheType: String of the type of caching to use for this response.
  * - foot: HTML string containing <script> tags of JS to execute.
  * - head: HTML string containing <link> and <style> tags of CSS to install.
@@ -155,6 +156,7 @@ spf.EventName = {
  * @typedef {{
  *   attr: (Object.<string, Object.<string, string>>|undefined),
  *   body: (Object.<string, string>|undefined),
+ *   cacheKey: (string|undefined),
  *   cacheType: (string|undefined),
  *   foot: (string|undefined),
  *   head: (string|undefined),
@@ -169,12 +171,14 @@ spf.SingleResponse;
 
 /**
  * Type definition for a multipart SPF response object.
+ * - cacheKey: Key used to cache this response.
  * - cacheType: String of the type of caching to use for this response.
  * - parts: List of response objects.
  * - timing: Map of timing attributes to timestamp numbers.
  * - type: The string "multipart".
  *
  * @typedef {{
+ *   cacheKey: (string|undefined),
  *   cacheType: (string|undefined),
  *   parts: (Array.<spf.SingleResponse>|undefined),
  *   timing: (Object.<string, number>|undefined),

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -109,6 +109,13 @@ spf.main.api_ = {
 };
 /** @private {!Object} */
 spf.main.extra_ = {
+  'cache': {
+    // Cache API.
+    // * Remove one entry.
+    'remove': spf.cache.remove,
+    // * Clear all entries.
+    'clear': spf.cache.clear
+  },
   'script': {
     // The bootloader API.
     // * Load scripts.

--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -389,6 +389,7 @@ spf.nav.request.done_ = function(url, options, timing, response, cache) {
                                                 response['cacheType'],
                                                 options.type, true);
     if (cacheKey) {
+      response['cacheKey'] = cacheKey;
       spf.nav.request.setCacheObject_(cacheKey, response, options.type || '');
     }
   }

--- a/src/client/nav/request_test.js
+++ b/src/client/nav/request_test.js
@@ -18,6 +18,7 @@ goog.require('spf.url');
 describe('spf.nav.request', function() {
 
   var MOCK_DELAY = 10;
+  var IGNORED_KEYS = ['cacheKey', 'timing']
   var options;
   var createFakeRegularXHR = function(xhrText, isMultipart) {
     var fakeXHR = {
@@ -128,7 +129,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -157,7 +158,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -184,7 +185,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -216,9 +217,9 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(xhrRes, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(xhrRes, IGNORED_KEYS);
       expect(onSuccessArgs[1]).not.toEqualObjectIgnoringKeys(cacheRes,
-                                                             ['timing']);
+                                                             IGNORED_KEYS);
     });
 
 
@@ -239,7 +240,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -280,7 +281,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -324,7 +325,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -394,7 +395,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -465,7 +466,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -512,7 +513,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -557,7 +558,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -598,7 +599,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -642,7 +643,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -712,7 +713,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -783,7 +784,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -807,7 +808,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -831,7 +832,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 
@@ -878,7 +879,7 @@ describe('spf.nav.request', function() {
       expect(options.onError.calls.length).toEqual(0);
       var onSuccessArgs = options.onSuccess.mostRecentCall.args;
       expect(onSuccessArgs[0]).toEqual(url);
-      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, ['timing']);
+      expect(onSuccessArgs[1]).toEqualObjectIgnoringKeys(res, IGNORED_KEYS);
     });
 
 


### PR DESCRIPTION
To support remove which requires a key, I add the cacheKey to the response object when inserting into cache.

This could also be achieved by trying to convert a URL into a key when removing, but that is always going to be a faulty process and likely to break during the edge cases, so while this is a bit more work for the application, it's far safer.

Closes #113 
