### PR TITLE
Preconnect specified links (experimental)

### DIFF
--- a/src/client/net/connect.js
+++ b/src/client/net/connect.js
@@ -1,0 +1,42 @@
+// Copyright 2014 Google Inc. All rights reserved.
+//
+// Use of this source code is governed by The MIT License.
+// See the LICENSE file for details.
+
+/**
+ * @fileoverview Functions for handling connections (i.e. pre-resolving DNS).
+ *
+ * @author nicksay@google.com (Alex Nicksay)
+ */
+
+goog.provide('spf.net.connect');
+
+goog.require('spf.array');
+goog.require('spf.net.resource');
+goog.require('spf.tracing');
+
+
+/**
+ * Preconnects to a URL.
+ * Use to both resolve DNS and establish a socket connections before requests
+ * are made.
+ *
+ * @param {string|Array.<string>} urls One or more URLs to preconnect.
+ */
+spf.net.connect.preconnect = function(urls) {
+  // Use an <img> tag to handle the preconnect in a compatible manner.
+  var type = spf.net.resource.Type.IMG;
+  // Convert to an array if needed.
+  urls = spf.array.toArray(urls);
+  spf.array.each(urls, function(url) {
+    spf.net.resource.prefetch(type, url);
+  });
+};
+
+
+if (spf.tracing.ENABLED) {
+  (function() {
+    spf.net.connect.preconnect = spf.tracing.instrument(
+        spf.net.connect.preconnect, 'spf.net.connect.preconnect');
+  })();
+}

--- a/src/client/net/resource.js
+++ b/src/client/net/resource.js
@@ -376,6 +376,7 @@ spf.net.resource.prefetch = function(type, url) {
  */
 spf.net.resource.prefetch_ = function(el, type, url, id, group) {
   var isJS = type == spf.net.resource.Type.JS;
+  var isCSS = type == spf.net.resource.Type.CSS;
   var doc = el.contentWindow.document;
   if (isJS) {
     var fetchEl = doc.createElement('object');
@@ -392,10 +393,16 @@ spf.net.resource.prefetch_ = function(el, type, url, id, group) {
     }
     fetchEl.id = id;
     doc.body.appendChild(fetchEl);
-  } else {
+  } else if (isCSS) {
     // Stylesheets can be prefetched in the same way as loaded.
     var fetchEl = spf.net.resource.create(type, url, null, doc, group);
     fetchEl.id = id;
+  } else {
+    // For establishing a preconnection, use an image request.
+    var fetchEl = doc.createElement('img');
+    fetchEl.src = url;
+    fetchEl.id = id;
+    doc.body.appendChild(fetchEl);
   }
 };
 
@@ -689,8 +696,7 @@ spf.net.resource.urls_ = {};
  * @type {boolean}
  * @const
  */
-spf.net.resource.IS_IE = spf.string.contains(
-    navigator.userAgent, ' Trident/');
+spf.net.resource.IS_IE = spf.string.contains(navigator.userAgent, ' Trident/');
 
 
 /**
@@ -709,6 +715,7 @@ spf.net.resource.State = {
  */
 spf.net.resource.Type = {
   CSS: 'css',
+  IMG: 'img',
   JS: 'js'
 };
 


### PR DESCRIPTION
When processing a response, parse `<link rel="preconnect">` tags, and initiate
connections via an `<img>` tag to both preresolve DNS for the target and
preconnect the socket.

For now, guard the feature behind a `experimental-preconnect` config.

Progress on #124.
