### PR TITLE
Release "unified execution" for scripts and styles.

### DIFF
--- a/src/client/nav/response.js
+++ b/src/client/nav/response.js
@@ -583,22 +583,14 @@ spf.nav.response.installScripts_ = function(result, opt_callback) {
       var item = result.scripts[index];
       var fn = function() {};
       if (item.url) {
-        if (spf.config.get('experimental-execute-unified')) {
-          if (item.name) {
-            fn = spf.bind(spf.net.script.load, null, item.url, item.name);
-          } else {
-            fn = spf.bind(spf.net.script.get, null, item.url);
-          }
-        } else {
+        if (item.name) {
           fn = spf.bind(spf.net.script.load, null, item.url, item.name);
+        } else {
+          fn = spf.bind(spf.net.script.get, null, item.url);
         }
       } else if (item.text) {
-        if (spf.config.get('experimental-execute-unified')) {
-          if (item.name) {
-            fn = spf.bind(spf.net.script.eval, null, item.text, item.name);
-          } else {
-            fn = spf.bind(spf.net.script.exec, null, item.text);
-          }
+        if (item.name) {
+          fn = spf.bind(spf.net.script.eval, null, item.text, item.name);
         } else {
           fn = spf.bind(spf.net.script.exec, null, item.text);
         }
@@ -652,22 +644,14 @@ spf.nav.response.installStyles_ = function(result) {
   for (var i = 0, l = result.styles.length; i < l; i++) {
     var item = result.styles[i];
     if (item.url) {
-      if (spf.config.get('experimental-execute-unified')) {
-        if (item.name) {
-          spf.net.style.load(item.url, item.name);
-        } else {
-          spf.net.style.get(item.url);
-        }
-      } else {
+      if (item.name) {
         spf.net.style.load(item.url, item.name);
+      } else {
+        spf.net.style.get(item.url);
       }
     } else if (item.text) {
-      if (spf.config.get('experimental-execute-unified')) {
-        if (item.name) {
-          spf.net.style.eval(item.text, item.name);
-        } else {
-          spf.net.style.exec(item.text);
-        }
+      if (item.name) {
+        spf.net.style.eval(item.text, item.name);
       } else {
         spf.net.style.exec(item.text);
       }


### PR DESCRIPTION
Promote previous `experimental-execute-unified` logic to be always enabled.

Inline script and style evaluation now always uses two functions:
- `eval`: conditionally evaluate the text only if changed
- `exec`: unconditionally execute the text

This matches the behavior of external script and style installation:
- `load`: conditionally install the resource only if changed
- `get`: unconditionally install the resource.

When processing a SPF response, the script and style execution rules are now:
- If an inline `<style>`, inline `<script>`, external `<link>`, or
  external `<script src>` with a `name` attribute is parsed, only execute
  if a style/script has not already been executed that matches the URL or
  text content.  Remove all other scripts and styles with the same name after
  executing.
- For all other scripts and styles (without a `name` attribute), execute
  unconditionally.

Progress on #25.
