### PR TITLE
Allow navigation to the same URL.

### DIFF
--- a/src/client/history/history.js
+++ b/src/client/history/history.js
@@ -196,7 +196,9 @@ spf.history.pop_ = function(evt) {
     spf.state.set(spf.state.Key.HISTORY_IGNORE_POP, false);
     return;
   }
-  // Avoid the initial event on first load for a state.
+  // Avoid the initial event on first load, and ignore events for history
+  // entries that are not handled by SPF (e.g. when navigating within a page
+  // using links with hash-only URLs, there are no associated states).
   if (!evt.state) {
     return;
   }

--- a/src/client/nav/nav_test.js
+++ b/src/client/nav/nav_test.js
@@ -384,6 +384,50 @@ describe('spf.nav', function() {
   });
 
 
+  describe('isNavigable', function() {
+
+
+    it('allows standard URLs to different pages', function() {
+      var current = window.location.href;
+      var url = '/page';
+      var crossDomainUrl = 'https://www.google.com/';
+      expect(spf.nav.isNavigable_(url, current)).toBe(true);
+      expect(spf.nav.isNavigable_(crossDomainUrl, current)).toBe(true);
+    });
+
+
+    it('allows hash URLs to different pages', function() {
+      var current = window.location.href;
+      var urlWithHash1 = '/page#target';
+      var crossDomainUrlWithHash1 = 'https://www.google.com/#target';
+      var urlWithHash2 = '/page#';
+      var crossDomainUrlWithHash2 = 'https://www.google.com/#';
+      expect(spf.nav.isNavigable_(urlWithHash1, current)).toBe(true);
+      expect(spf.nav.isNavigable_(crossDomainUrlWithHash1, current)).toBe(true);
+      expect(spf.nav.isNavigable_(urlWithHash2, current)).toBe(true);
+      expect(spf.nav.isNavigable_(crossDomainUrlWithHash2, current)).toBe(true);
+    });
+
+
+    it('allows standard URLs to same pages', function() {
+      var current = window.location.href;
+      var url = current;
+      expect(spf.nav.isNavigable_(url, current)).toBe(true);
+    });
+
+
+    it('denies hash URLs to same pages', function() {
+      var current = window.location.href;
+      var urlWithHash1 = current + '#target';
+      var urlWithHash2 = current + '#';
+      expect(spf.nav.isNavigable_(urlWithHash1, current)).toBe(false);
+      expect(spf.nav.isNavigable_(urlWithHash2, current)).toBe(false);
+    });
+
+
+  });
+
+
   describe('navigate', function() {
 
 

--- a/src/client/net/resource.js
+++ b/src/client/net/resource.js
@@ -93,7 +93,7 @@ spf.net.resource.load = function(type, urls, opt_nameOrFn, opt_fn) {
   spf.net.resource.urls.set(type, pseudonym, urls);
   // Subscribe the callback to execute when all urls are loaded.
   var topic = spf.net.resource.key(type, pseudonym);
-  spf.debug.debug('  subscribing', topic, done);
+  spf.debug.debug('  subscribing', topic);
   spf.pubsub.subscribe(topic, done);
   // Start asynchronously loading all the resources.
   spf.array.each(urls, function(url) {

--- a/src/client/state.js
+++ b/src/client/state.js
@@ -70,7 +70,6 @@ spf.state.Key = {
   NAV_PREFETCHES: 'nav-prefetches',
   NAV_PROMOTE: 'nav-promote',
   NAV_PROMOTE_TIME: 'nav-promote-time',
-  NAV_REFERER: 'nav-referer',
   NAV_REQUEST: 'nav-request',
   PREFETCH_LISTENER: 'prefetch-listener',
   PUBSUB_SUBS: 'ps-s',

--- a/src/client/url/url.js
+++ b/src/client/url/url.js
@@ -74,14 +74,15 @@ spf.url.utils = function(url) {
 
 /**
  * Converts a relative URL to absolute based on the current document domain.
- * Also removes the fragment from the URL, if one exists.
  *
  * @param {string} relative A relative URL.
+ * @param {boolean=} opt_keepHash  Whether to keep any hash in the URL,
+ *     if one exists.  Defaults to false.
  * @return {string} An absolute URL (with fragment removed, if possible).
  */
-spf.url.absolute = function(relative) {
+spf.url.absolute = function(relative, opt_keepHash) {
   var utils = spf.url.utils(relative);
-  return spf.url.unfragment(utils.href);
+  return opt_keepHash ? utils.href : spf.url.unfragment(utils.href);
 };
 
 

--- a/src/server/demo/templates/demo.tmpl
+++ b/src/server/demo/templates/demo.tmpl
@@ -50,6 +50,10 @@ $def _stylesheet():
     .demo td.no {
       background-color: #FEE;
     }
+    #demo-target {
+      text-align: center;
+      margin: 50em 0 10em;  /* for testing scrolling */
+    }
   </style>
   <link rel="stylesheet" href="/static/app-demo.css" name="demo-external">
 
@@ -214,6 +218,36 @@ $var attributes: $:_attributes()
     </tbody>
     <tbody>
       <tr>
+        <td><code>href</code> attribute with path and hash</td>
+        <td class="yes">Yes</td>
+        <td class="yes">Yes</td>
+      </tr>
+      <tr>
+        <td><code>&lt;a class="spf-link" href="<em> &hellip; </em>#<em> &hellip; </em>"&gt;</code></td>
+        <td colspan="2">
+          <a class="spf-link" href="/demo/1#demo-target">Demo 1 Target</a>
+          <a class="spf-link" href="/demo/2#demo-target">Demo 2 Target</a>
+          <a class="spf-link" href="/demo/3#demo-target">Demo 3 Target</a>
+          <a class="spf-link" href="/demo/4#demo-target">Demo 4 Target</a>
+          <a class="spf-link" href="/demo/5#demo-target">Demo 5 Target</a>
+        </td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr>
+        <td><code>href</code> attribute with only hash</td>
+        <td class="no">No</td>
+        <td class="no">No</td>
+      </tr>
+      <tr>
+        <td><code>&lt;a class="spf-link" href="#<em> &hellip; </em>"&gt;</code></td>
+        <td colspan="2">
+          <a class="spf-link" href="#demo-target">Demo Target</a>
+        </td>
+      </tr>
+    </tbody>
+    <tbody>
+      <tr>
         <td><code>spf.navigate</code> JS API</td>
         <td class="yes">Yes</td>
         <td class="yes">Yes</td>
@@ -264,5 +298,9 @@ $var attributes: $:_attributes()
       </tr>
     </tbody>
   </table>
+
+  <p id="demo-target">
+    This is a target for testing scrolling support.  &nbsp;&nbsp;  <a href="#">Top</a>
+  </p>
 
 </div>


### PR DESCRIPTION
Update event handling to no longer ignore clicks and `spf.navigate` calls to
the same URL.

If navigating to the same URL and it contains a hash (e.g. from `/page` to
`/page#target`), short-circuit, attempt to scroll instead of sending a request,
and add a history entry for the destination.  This matches browser behavior.

If a navigation to the same URL occurs, either a by request or scroll, update
the existing history entry instead of adding a new one.  This also matches
browser behavior.

Closes #126.
