### PR TITLE
Add linter on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 python:
   - "2.7"
+install:
+  - easy_install http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz
 before_script:
   - make
   - make tests
+  - make lint
 script:
   phantomjs build/test/run-jasmine.js build/test/runner.html

--- a/configure.py
+++ b/configure.py
@@ -324,6 +324,7 @@ def write_rules(ninja):
   ninja.comment('Setup python packages.')
   ninja.rule('setup',
              command=('cd $dir '
+                      '&& export PYTHONPATH="$$PWD/lib/python2.7/site-packages/:$$PYTHONPATH" '
                       '&& export PYTHONUSERBASE="$$PWD" '
                       '&& python setup.py -q install --user '
                       '&& python setup.py -q clean --all'),

--- a/src/client/net/resource.js
+++ b/src/client/net/resource.js
@@ -549,7 +549,7 @@ spf.net.resource.canonicalize = function(type, url) {
  * @return {string} The compound key.
  */
 spf.net.resource.key = function(type, label, opt_group) {
-  return type + '-' + label + (opt_group ?  '-' + opt_group : '');
+  return type + '-' + label + (opt_group ? '-' + opt_group : '');
 };
 
 


### PR DESCRIPTION
This PR adds Google Closure Linter (`make lint`) before Jasmine tests on Travis-CI.
It also fixes a nit lint error detected by gjslinter.
