### PR TITLE
Update API to allow only one URL per name during script/style loading.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -275,7 +275,7 @@ spf.EventDetail.prototype.err;
 
 
 /**
- * The name of the scripts or styles that will be unloaded; defined for
+ * The name of the scripts or stylesheets that will be unloaded; defined for
  * "spfjsbeforeunload", "spfjsunload", "spfcssbeforeunload", and
  * "spfcssunload" events.
  * @type {string|undefined}
@@ -341,8 +341,8 @@ spf.EventDetail.prototype.url;
 
 
 /**
- * The list of URLs of the scripts or styles that will be unloaded; defined for
- * "spfjsbeforeunload", "spfjsunload", "spfcssbeforeunload", and
+ * The list of URLs of the scripts or stylesheets that will be unloaded; defined
+ * for "spfjsbeforeunload", "spfjsunload", "spfcssbeforeunload", and
  * "spfcssunload" events.
  * @type {Array.<string>|undefined}
  */
@@ -492,10 +492,9 @@ spf.script = {};
 
 
 /**
- * Loads one or more scripts asynchronously and defines a name to
- * use for dependency management and unloading.  See {@link #ready} to wait
- * for named scripts to be loaded and {@link #unload} to remove previously
- * loaded scripts.
+ * Loads a script asynchronously and defines a name to use for dependency
+ * management and unloading.  See {@link #ready} to wait for named scripts to
+ * be loaded and {@link #unload} to remove previously loaded scripts.
  *
  * - Subsequent calls to load the same URL will not reload the script.  To
  *   reload a script, unload it first with {@link #unload}.  To unconditionally
@@ -510,16 +509,16 @@ spf.script = {};
  * - A callback can be specified to execute once the script has loaded.  The
  *   callback will be executed each time, even if the script is not reloaded.
  *
- * @param {string|Array.<string>} urls One or more URLs of scripts to load.
- * @param {string} name Name to identify the scripts.
+ * @param {string} url URL of the script to load.
+ * @param {string} name Name to identify the script.
  * @param {Function=} opt_fn Optional callback function to execute when the
- *     scripts are loaded.
+ *     script is loaded.
  */
-spf.script.load = function(urls, name, opt_fn) {};
+spf.script.load = function(url, name, opt_fn) {};
 
 
 /**
- * Unloads scripts identified by name.  See {@link #load}.
+ * Unloads a script identified by name.  See {@link #load}.
  *
  * NOTE: Unloading a script will prevent execution of ALL pending callbacks
  * but is NOT guaranteed to stop the browser loading a pending URL.
@@ -603,7 +602,7 @@ spf.script.unrequire = function(names) {};
  * See {@link #require}.
  *
  * @param {Object.<(string|Array.<string>)>} deps The dependency map.
- * @param {Object.<(string|Array.<string>)>=} opt_urls The optional URL map.
+ * @param {Object.<string>=} opt_urls The optional URL map.
  */
 spf.script.declare = function(deps, opt_urls) {};
 
@@ -617,6 +616,7 @@ spf.script.declare = function(deps, opt_urls) {};
  */
 spf.script.path = function(paths) {};
 
+
 /**
  * Prefetchs one or more scripts; the scripts will be requested but not loaded.
  * Use to prime the browser cache and avoid needing to request the script when
@@ -628,53 +628,55 @@ spf.script.prefetch = function(urls) {};
 
 
 /**
- * Namespace for style-loading functions.
+ * Namespace for stylesheet-loading functions.
  */
 spf.style = {};
 
 
 /**
- * Loads one or more styles asynchronously and defines a name to
- * use for dependency management and unloading.  See {@link #unload} to
- * remove previously loaded styles.
+ * Loads a stylesheet asynchronously and defines a name to use for dependency
+ * management and unloading.  See {@link #unload} to remove previously loaded
+ * stylesheets.
  *
- * - Subsequent calls to load the same URL will not reload the style.  To
- *   reload a style, unload it first with {@link #unload}.  To unconditionally
- *   load a style, see {@link #get}.
+ * - Subsequent calls to load the same URL will not reload the stylesheet.  To
+ *   reload a stylesheet, unload it first with {@link #unload}.  To
+ *   unconditionally load a stylesheet, see {@link #get}.
  *
- * - A name must be specified to identify the same style at different URLs.
+ * - A name must be specified to identify the same stylesheet at different URLs.
  *   (For example, "main-A.css" and "main-B.css" are both "main".)  When a name
- *   is specified, all other styles with the same name will be unloaded.
- *   This allows switching between versions of the same style at different URLs.
+ *   is specified, all other stylesheets with the same name will be unloaded.
+ *   This allows switching between versions of the same stylesheet at different
+ *   URLs.
  *
- * - A callback can be specified to execute once the style has loaded.  The
- *   callback will be executed each time, even if the style is not reloaded.
- *   NOTE: Unlike scripts, this callback is best effort and is supported
- *   in the following browser versions: IE 6, Chrome 19, Firefox 9, Safari 6.
+ * - A callback can be specified to execute once the stylesheet has loaded.  The
+ *   callback will be executed each time, even if the stylesheet is not
+ *   reloaded.  NOTE: Unlike scripts, this callback is best effort and is
+ *   supported in the following browser versions: IE 6, Chrome 19, Firefox 9,
+ *   Safari 6.
  *
- * @param {string|Array.<string>} urls One or more URLs of styles to load.
- * @param {string} name Name to identify the styles.
+ * @param {string} url URL of the stylesheet to load.
+ * @param {string} name Name to identify the stylesheet.
  * @param {Function=} opt_fn Optional callback function to execute when the
- *     styles are loaded.
+ *     stylesheet is loaded.
  */
-spf.style.load = function(urls, name, opt_fn) {};
+spf.style.load = function(url, name, opt_fn) {};
 
 
 /**
- * Unloads styles identified by name.  See {@link #load}.
+ * Unloads a stylesheet identified by name.  See {@link #load}.
  *
- * @param {string} name The name of the style(s).
+ * @param {string} name Name of the stylesheet.
  */
 spf.style.unload = function(name) {};
 
 
 /**
- * Unconditionally loads a style by dynamically creating an element and
+ * Unconditionally loads a stylesheet by dynamically creating an element and
  * appending it to the document without regard for whether it has been loaded
- * before. A style directly loaded by this method cannot be unloaded by name.
- * Compare to {@link #load}.
+ * before. A stylesheet directly loaded by this method cannot be unloaded by
+ * name.  Compare to {@link #load}.
  *
- * @param {string} url The URL of the style to load.
+ * @param {string} url URL of the stylesheet to load.
  */
 spf.style.get = function(url) {};
 
@@ -690,10 +692,10 @@ spf.style.path = function(paths) {};
 
 
 /**
- * Prefetchs one or more styles; the styles will be requested but not loaded.
- * Use to prime the browser cache and avoid needing to request the style when
- * subsequently loaded.  See {@link #load}.
+ * Prefetchs one or more stylesheets; the stylesheets will be requested but not
+ * loaded. Use to prime the browser cache and avoid needing to request the
+ * stylesheet when subsequently loaded.  See {@link #load}.
  *
- * @param {string|Array.<string>} urls One or more URLs of styles to prefetch.
+ * @param {string|Array.<string>} urls One or more stylesheet URLs to prefetch.
  */
 spf.style.prefetch = function(urls) {};

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -227,7 +227,7 @@ spf.RequestOptions;
 /**
  * Type definition for custom event detail (data), also used for callbacks.
  * - err: optional error that occurred; defined for "error" events
- * - name: optional name of the scripts or styles that will be unloaded;
+ * - name: optional name of the scripts or stylesheets that will be unloaded;
  *       defined for "jsbeforeunload", "jsunload", "cssbeforeunload",
  *       and "cssunload" events.
  * - part: optional part of a multipart response; defined for "partprocess"
@@ -243,8 +243,8 @@ spf.RequestOptions;
  * - url: optional URL of the request; defined for "error", "reload", "click",
  *       "history", "request", "partprocess", "partdone", "process", and "done"
  *       events.
- * - urls: optional list or URLs of scripts/styles to be unloaded; defined for
- *       "jsbeforeunload", "jsunload", "cssbeforeunload", and "cssunload"
+ * - urls: optional list or URLs of scripts/stylesheets to be unloaded; defined
+ *       for "jsbeforeunload", "jsunload", "cssbeforeunload", and "cssunload"
  *       events.
  *
  * @typedef {{

--- a/src/client/net/resource.js
+++ b/src/client/net/resource.js
@@ -5,7 +5,7 @@
 
 /**
  * @fileoverview Functions for loading and unloading external resources such
- * as scripts and styles.
+ * as scripts and stylesheets.
  * See {@link spf.net.script} and {@link spf.net.style}.
  *
  * @author nicksay@google.com (Alex Nicksay)
@@ -29,25 +29,31 @@ goog.require('spf.url');
 
 
 /**
- * Loads resources asynchronously and optionally defines a name to use for
+ * Loads a resource asynchronously and optionally defines a name to use for
  * dependency management and unloading.  See {@link #unload} to remove
  * previously loaded resources.
  *
- * NOTE: Automatic unloading of styles depends on "onload" support and is
+ * NOTE: Automatic unloading of stylesheets depends on "onload" support and is
  * best effort.  Chrome 19, Safari 6, Firefox 9, Opera and IE 5.5 are supported.
  *
- * @param {spf.net.resource.Type} type Type of the resources.
- * @param {string|Array.<string>} urls One or more URLs of resources to load.
- * @param {string} name Name to identify the resources.
+ * @param {spf.net.resource.Type} type Type of the resource.
+ * @param {string} url URL of the resource to load.
+ * @param {string} name Name to identify the resource.
  * @param {Function=} opt_fn Optional callback function to execute when the
- *     resources are loaded.
+ *     resource is loaded.
  */
-spf.net.resource.load = function(type, urls, name, opt_fn) {
+spf.net.resource.load = function(type, url, name, opt_fn) {
+  spf.debug.debug('resource.load', type, url, name);
   var isJS = type == spf.net.resource.Type.JS;
 
   // Convert to an array if needed.
-  urls = spf.array.toArray(urls);
-  spf.debug.debug('resource.load', type, urls, name);
+  var urls = spf.array.toArray(url);
+  if (!SPF_BOOTLOADER && urls.length > 1) {
+    // TODO(nicksay): Remove compatibility code before next release.
+    setTimeout(function() {
+      throw new Error(type + ' load called with too many urls ' + urls);
+    }, 0);
+  }
 
   var canonicalize = spf.bind(spf.net.resource.canonicalize, null, type);
   urls = spf.array.map(urls, canonicalize);

--- a/src/client/net/script.js
+++ b/src/client/net/script.js
@@ -44,10 +44,9 @@ goog.require('spf.tracing');
 
 
 /**
- * Loads one or more scripts asynchronously and defines a name to
- * use for dependency management and unloading.  See {@link #ready} to wait
- * for named scripts to be loaded and {@link #unload} to remove previously
- * loaded scripts.
+ * Loads a script asynchronously and defines a name to use for dependency
+ * management and unloading.  See {@link #ready} to wait for named scripts to
+ * be loaded and {@link #unload} to remove previously loaded scripts.
  *
  * - Subsequent calls to load the same URL will not reload the script.  To
  *   reload a script, unload it first with {@link #unload}.  To unconditionally
@@ -62,14 +61,14 @@ goog.require('spf.tracing');
  * - A callback can be specified to execute once the script has loaded.  The
  *   callback will be executed each time, even if the script is not reloaded.
  *
- * @param {string|Array.<string>} urls One or more URLs of scripts to load.
- * @param {string} name Name to identify the scripts.
+ * @param {string} url URL of the script to load.
+ * @param {string} name Name to identify the script.
  * @param {Function=} opt_fn Optional callback function to execute when the
- *     scripts are loaded.
+ *     script is loaded.
  */
-spf.net.script.load = function(urls, name, opt_fn) {
+spf.net.script.load = function(url, name, opt_fn) {
   var type = spf.net.resource.Type.JS;
-  spf.net.resource.load(type, urls, name, opt_fn);
+  spf.net.resource.load(type, url, name, opt_fn);
 };
 
 
@@ -102,7 +101,7 @@ spf.net.script.discover = function() {
  * has been loaded before.  A script directly loaded by this method cannot
  * be unloaded by name.  Compare to {@link #load}.
  *
- * @param {string} url The URL of the script to load.
+ * @param {string} url URL of the script to load.
  * @param {Function=} opt_fn Function to execute when loaded.
  */
 spf.net.script.get = function(url, opt_fn) {
@@ -257,9 +256,14 @@ spf.net.script.require_ = function(names) {
   // If not, load the scripts for that name.
   spf.array.each(names, function(name) {
     var deps = spf.net.script.deps_[name];
-    var urls = spf.net.script.urls_[name] || name;
+    var url = spf.net.script.urls_[name] || name;
     var next = function() {
-      spf.net.script.load(urls, name);
+      // TODO(nicksay): Remove compatibility code before next release.
+      // Trick the compiler.  While the compatibility code is in place, existing
+      // urls in state might be arrays instead of strings.  This support
+      // will be removed soon, but until it is, cast the variable.
+      url = /** @type {string} */ (url);
+      spf.net.script.load(url, name);
     };
     if (deps) {
       spf.net.script.require(deps, next);
@@ -331,7 +335,7 @@ spf.net.script.exec = function(text) {
  * See {@link #require}.
  *
  * @param {Object.<(string|Array.<string>)>} deps The dependency map.
- * @param {Object.<(string|Array.<string>)>=} opt_urls The optional URL map.
+ * @param {Object.<string>=} opt_urls The optional URL map.
  */
 spf.net.script.declare = function(deps, opt_urls) {
   if (deps) {

--- a/src/client/net/style.js
+++ b/src/client/net/style.js
@@ -4,7 +4,7 @@
 // See the LICENSE file for details.
 
 /**
- * @fileoverview Functions for dynamically loading styles.
+ * @fileoverview Functions for dynamically loading stylesheets.
  *
  * @author nicksay@google.com (Alex Nicksay)
  */
@@ -18,37 +18,39 @@ goog.require('spf.tracing');
 
 
 /**
- * Loads one or more styles asynchronously and defines a name to
- * use for dependency management and unloading.  See {@link #unload} to
- * remove previously loaded styles.
+ * Loads a stylesheet asynchronously and defines a name to use for dependency
+ * management and unloading.  See {@link #unload} to remove previously loaded
+ * stylesheets.
  *
- * - Subsequent calls to load the same URL will not reload the style.  To
- *   reload a style, unload it first with {@link #unload}.  To unconditionally
- *   load a style, see {@link #get}.
+ * - Subsequent calls to load the same URL will not reload the stylesheet.  To
+ *   reload a stylesheet, unload it first with {@link #unload}.  To
+ *   unconditionally load a stylesheet, see {@link #get}.
  *
- * - A name must be specified to identify the same style at different URLs.
+ * - A name must be specified to identify the same stylesheet at different URLs.
  *   (For example, "main-A.css" and "main-B.css" are both "main".)  When a name
- *   is specified, all other styles with the same name will be unloaded.
- *   This allows switching between versions of the same style at different URLs.
+ *   is specified, all other stylesheets with the same name will be unloaded.
+ *   This allows switching between versions of the same stylesheet at different
+ *   URLs.
  *
- * - A callback can be specified to execute once the style has loaded.  The
- *   callback will be executed each time, even if the style is not reloaded.
- *   NOTE: Unlike scripts, this callback is best effort and is supported
- *   in the following browser versions: IE 6, Chrome 19, Firefox 9, Safari 6.
+ * - A callback can be specified to execute once the stylesheet has loaded.  The
+ *   callback will be executed each time, even if the stylesheet is not
+ *   reloaded.  NOTE: Unlike scripts, this callback is best effort and is
+ *   supported in the following browser versions: IE 6, Chrome 19, Firefox 9,
+ *   Safari 6.
  *
- * @param {string|Array.<string>} urls One or more URLs of styles to load.
- * @param {string} name Name to identify the styles.
+ * @param {string} url URL of the stylesheet to load.
+ * @param {string} name Name to identify the stylesheet.
  * @param {Function=} opt_fn Optional callback function to execute when the
- *     styles are loaded.
+ *     stylesheet is loaded.
  */
-spf.net.style.load = function(urls, name, opt_fn) {
+spf.net.style.load = function(url, name, opt_fn) {
   var type = spf.net.resource.Type.CSS;
-  spf.net.resource.load(type, urls, name, opt_fn);
+  spf.net.resource.load(type, url, name, opt_fn);
 };
 
 
 /**
- * Unloads styles identified by dependency name.  See {@link #load}.
+ * Unloads a stylesheet identified by dependency name.  See {@link #load}.
  *
  * @param {string} name The dependency name.
  */
@@ -59,7 +61,7 @@ spf.net.style.unload = function(name) {
 
 
 /**
- * Discovers existing styles in the document and registers them as loaded.
+ * Discovers existing stylesheets in the document and registers them as loaded.
  */
 spf.net.style.discover = function() {
   var type = spf.net.resource.Type.CSS;
@@ -68,12 +70,12 @@ spf.net.style.discover = function() {
 
 
 /**
- * Unconditionally loads a style by dynamically creating an element and
+ * Unconditionally loads a stylesheet by dynamically creating an element and
  * appending it to the document without regard for whether it has been loaded
- * before. A style directly loaded by this method cannot be unloaded by name.
- * Compare to {@link #load}.
+ * before. A stylesheet directly loaded by this method cannot be unloaded by
+ * name.  Compare to {@link #load}.
  *
- * @param {string} url The URL of the style to load.
+ * @param {string} url URL of the stylesheet to load.
  * @param {Function=} opt_fn Function to execute when loaded.
  */
 spf.net.style.get = function(url, opt_fn) {
@@ -85,11 +87,11 @@ spf.net.style.get = function(url, opt_fn) {
 
 
 /**
- * Prefetchs one or more styles; the styles will be requested but not loaded.
- * Use to prime the browser cache and avoid needing to request the style when
- * subsequently loaded.  See {@link #load}.
+ * Prefetchs one or more stylesheets; the stylesheets will be requested but not
+ * loaded.  Use to prime the browser cache and avoid needing to request the
+ * stylesheet when subsequently loaded.  See {@link #load}.
  *
- * @param {string|Array.<string>} urls One or more URLs of styles to prefetch.
+ * @param {string|Array.<string>} urls One or more stylesheet URLs to prefetch.
  */
 spf.net.style.prefetch = function(urls) {
   var type = spf.net.resource.Type.CSS;


### PR DESCRIPTION
To maintain backwards compatibility across versions, this change only updates
the API documentation and throws a non-blocking error if an unsupported array
of URLs is passed instead of a single URL.  Afterwards, a following change can
safely transition the implementation without affecting the API.

Progress on #25.
