### PR TITLE
Update resource loading implementation to handle only one URL per name

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -334,7 +334,9 @@ spf.EventDetail.prototype.target;
 /**
  * The URL of the request; defined for "spferror", "spfreload", "spfclick",
  * "spfhistory", "spfrequest", "spfpartprocess", "spfpartdone", "spfprocess",
- * and "spfdone" events.
+ * and "spfdone" events - or - the URL of the script or stylesheet that will
+ * be unloaded; defined for "spfjsbeforeunload", "spfjsunload",
+ * "spfcssbeforeunload", and "spfcssunload" events.
  * @type {string|undefined}
  */
 spf.EventDetail.prototype.url;
@@ -345,6 +347,9 @@ spf.EventDetail.prototype.url;
  * for "spfjsbeforeunload", "spfjsunload", "spfcssbeforeunload", and
  * "spfcssunload" events.
  * @type {Array.<string>|undefined}
+ * @deprecated Use {@link #url} instead. This will always be a single item
+ *   array containing the URL and the property will be removed in the next
+ *   release.
  */
 spf.EventDetail.prototype.urls;
 

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -227,7 +227,7 @@ spf.RequestOptions;
 /**
  * Type definition for custom event detail (data), also used for callbacks.
  * - err: optional error that occurred; defined for "error" events
- * - name: optional name of the scripts or stylesheets that will be unloaded;
+ * - name: optional name of the script or stylesheet that will be unloaded;
  *       defined for "jsbeforeunload", "jsunload", "cssbeforeunload",
  *       and "cssunload" events.
  * - part: optional part of a multipart response; defined for "partprocess"
@@ -242,10 +242,9 @@ spf.RequestOptions;
  * - target: optional target element; defined for "click" events.
  * - url: optional URL of the request; defined for "error", "reload", "click",
  *       "history", "request", "partprocess", "partdone", "process", and "done"
- *       events.
- * - urls: optional list or URLs of scripts/stylesheets to be unloaded; defined
- *       for "jsbeforeunload", "jsunload", "cssbeforeunload", and "cssunload"
- *       events.
+ *       events - or - optional URL of the script/stylesheet that will be
+ *       unloaded; defined for "jsbeforeunload", "jsunload", "cssbeforeunload",
+ *       and "cssunload" events.
  *
  * @typedef {{
  *   err: (Error|undefined),
@@ -256,8 +255,7 @@ spf.RequestOptions;
  *   referer: (string|undefined),
  *   target: (Element|undefined),
  *   response: (spf.SingleResponse|spf.MultipartResponse|undefined),
- *   url: (string|undefined),
- *   urls: (Array.<string>|undefined)
+ *   url: (string|undefined)
  * }}
  */
 spf.EventDetail;

--- a/src/client/net/resource_test.js
+++ b/src/client/net/resource_test.js
@@ -120,7 +120,7 @@ describe('spf.net.resource', function() {
 
     spf.state.values_ = {};
     spf.pubsub.subscriptions = {};
-    spf.net.resource.urls_ = {};
+    spf.net.resource.url_ = {};
     spf.net.resource.status_ = {};
 
     nodes = [new FakeElement('head')];
@@ -139,7 +139,7 @@ describe('spf.net.resource', function() {
 
   describe('load', function() {
 
-    it('a single url (script)', function() {
+    it('a url (script)', function() {
       spf.net.resource.load(JS, 'url-a.js');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(1);
@@ -153,7 +153,7 @@ describe('spf.net.resource', function() {
       expect(getScriptEls().length).toEqual(2);
     });
 
-    it('a single url (style)', function() {
+    it('a url (style)', function() {
       spf.net.resource.load(CSS, 'url-a.css');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(1);
@@ -167,7 +167,7 @@ describe('spf.net.resource', function() {
       expect(getStyleEls().length).toEqual(2);
     });
 
-    it('a single url with a name (script)', function() {
+    it('a url with a name (script)', function() {
       spf.net.resource.load(JS, 'url-a.js', 'a');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(1);
@@ -181,7 +181,7 @@ describe('spf.net.resource', function() {
       expect(getScriptEls().length).toEqual(2);
     });
 
-    it('a single url with a name (style)', function() {
+    it('a url with a name (style)', function() {
       spf.net.resource.load(CSS, 'url-a.css', 'a');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(1);
@@ -195,21 +195,21 @@ describe('spf.net.resource', function() {
       expect(getStyleEls().length).toEqual(2);
     });
 
-    it('a single url with an in progress name (script)', function() {
+    it('a url with an in progress name (script)', function() {
       spf.net.resource.load(JS, 'url-a.js', 'a');
       spf.net.resource.load(JS, 'url-a.js', 'a');
       jasmine.Clock.tick(1);
       expect(getScriptEls().length).toEqual(1);
     });
 
-    it('a single url with an in progress name (style)', function() {
+    it('a url with an in progress name (style)', function() {
       spf.net.resource.load(CSS, 'url-a.css', 'a');
       spf.net.resource.load(CSS, 'url-a.css', 'a');
       jasmine.Clock.tick(1);
       expect(getStyleEls().length).toEqual(1);
     });
 
-    it('a single url with a mismatch in progress name (script)', function() {
+    it('a url with a mismatch in progress name (script)', function() {
       spf.net.resource.load(JS, 'url-a.js', 'a');
       spf.net.resource.load(JS, 'url-b.js', 'a');
       jasmine.Clock.tick(1);
@@ -217,7 +217,7 @@ describe('spf.net.resource', function() {
       expect(getScriptUrls()).toContain('//test/url-b.js');
     });
 
-    it('a single url with a mismatch in progress name (style)', function() {
+    it('a url with a mismatch in progress name (style)', function() {
       spf.net.resource.load(CSS, 'url-a.css', 'a');
       spf.net.resource.load(CSS, 'url-b.css', 'a');
       jasmine.Clock.tick(1);
@@ -225,118 +225,12 @@ describe('spf.net.resource', function() {
       expect(getStyleUrls()).toContain('//test/url-b.css');
     });
 
-    it('multiple urls (script)', function() {
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js']);
-      jasmine.Clock.tick(1);
-      expect(getScriptEls().length).toEqual(2);
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js']);
-      jasmine.Clock.tick(1);
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js']);
-      jasmine.Clock.tick(1);
-      expect(getScriptEls().length).toEqual(2);
-      spf.net.resource.load(JS, ['url-b-1.js', 'url-b-2.js']);
-      jasmine.Clock.tick(1);
-      expect(getScriptEls().length).toEqual(4);
-    });
-
-    it('multiple urls (style)', function() {
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css']);
-      jasmine.Clock.tick(1);
-      expect(getStyleEls().length).toEqual(2);
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css']);
-      jasmine.Clock.tick(1);
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css']);
-      jasmine.Clock.tick(1);
-      expect(getStyleEls().length).toEqual(2);
-      spf.net.resource.load(CSS, ['url-b-1.css', 'url-b-2.css']);
-      jasmine.Clock.tick(1);
-      expect(getStyleEls().length).toEqual(4);
-    });
-
-    it('multiple urls with a name (script)', function() {
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getScriptEls().length).toEqual(2);
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
-      jasmine.Clock.tick(1);
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getScriptEls().length).toEqual(2);
-      spf.net.resource.load(JS, ['url-b-1.js', 'url-b-2.js'], 'b');
-      jasmine.Clock.tick(1);
-      expect(getScriptEls().length).toEqual(4);
-    });
-
-    it('multiple urls with a name (style)', function() {
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getStyleEls().length).toEqual(2);
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
-      jasmine.Clock.tick(1);
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getStyleEls().length).toEqual(2);
-      spf.net.resource.load(CSS, ['url-b-1.css', 'url-b-2.css'], 'b');
-      jasmine.Clock.tick(1);
-      expect(getStyleEls().length).toEqual(4);
-    });
-
-    it('multiple urls with an in progress name (script)', function() {
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getScriptEls().length).toEqual(2);
-    });
-
-    it('multiple urls with an in progress name (style)', function() {
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getStyleEls().length).toEqual(2);
-    });
-
-    it('multiple urls with a mismatched in progress name (script)', function() {
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
-      spf.net.resource.load(JS, ['url-a-3.js', 'url-a-4.js'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getScriptEls().length).toEqual(2);
-      expect(getScriptUrls()).toContain('//test/url-a-3.js');
-      expect(getScriptUrls()).toContain('//test/url-a-4.js');
-    });
-
-    it('multiple urls with a mismatched in progress name (style)', function() {
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
-      spf.net.resource.load(CSS, ['url-a-3.css', 'url-a-4.css'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getStyleEls().length).toEqual(2);
-      expect(getStyleUrls()).toContain('//test/url-a-3.css');
-      expect(getStyleUrls()).toContain('//test/url-a-4.css');
-    });
-
-    it('multiple urls with a partially mismatched name (script)', function() {
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-4.js'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getScriptEls().length).toEqual(2);
-      expect(getScriptUrls()).toContain('//test/url-a-1.js');
-      expect(getScriptUrls()).toContain('//test/url-a-4.js');
-    });
-
-    it('multiple urls with a partially mismatched name (style)', function() {
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-4.css'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getStyleEls().length).toEqual(2);
-      expect(getStyleUrls()).toContain('//test/url-a-1.css');
-      expect(getStyleUrls()).toContain('//test/url-a-4.css');
-    });
-
   });
 
 
   describe('unload', function() {
 
-    it('a single url by name (script)', function() {
+    it('a url by name (script)', function() {
       // Load a URL.
       spf.net.resource.load(JS, 'url-a.js', 'a');
       jasmine.Clock.tick(1);
@@ -352,7 +246,7 @@ describe('spf.net.resource', function() {
       expect(getScriptUrls()).not.toContain('//test/url-a.js');
     });
 
-    it('a single url by name (style)', function() {
+    it('a url by name (style)', function() {
       // Load a URL.
       spf.net.resource.load(CSS, 'url-a.css', 'a');
       jasmine.Clock.tick(1);
@@ -366,84 +260,6 @@ describe('spf.net.resource', function() {
       spf.net.resource.unload(CSS, 'a');
       expect('//test/url-a.css' in spf.net.resource.status_).toBe(false);
       expect(getStyleUrls()).not.toContain('//test/url-a.css');
-    });
-
-    it('multiple urls by name (script)', function() {
-      // Load some URLs (and check that they are "ready").
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getScriptUrls()).toContain('//test/url-a-1.js');
-      expect(getScriptUrls()).toContain('//test/url-a-2.js');
-      // Remove them (and check that they are no longer "ready").
-      spf.net.resource.unload(JS, 'a');
-      expect('//test/url-a-1.js' in spf.net.resource.status_).toBe(false);
-      expect('//test/url-a-2.js' in spf.net.resource.status_).toBe(false);
-      expect(getScriptUrls()).not.toContain('//test/url-a-1.js');
-      expect(getScriptUrls()).not.toContain('//test/url-a-2.js');
-      // Repeated calls should be no-ops.
-      spf.net.resource.unload(JS, 'a');
-      spf.net.resource.unload(JS, 'a');
-      expect('//test/url-a-1.js' in spf.net.resource.status_).toBe(false);
-      expect('//test/url-a-2.js' in spf.net.resource.status_).toBe(false);
-      expect(getScriptUrls()).not.toContain('//test/url-a-1.js');
-      expect(getScriptUrls()).not.toContain('//test/url-a-2.js');
-      // Check multiple names.
-      spf.net.resource.load(JS, ['url-a-1.js', 'url-a-2.js'], 'a');
-      spf.net.resource.load(JS, ['url-b-1.js', 'url-b-2.js'], 'b');
-      jasmine.Clock.tick(1);
-      expect(getScriptUrls()).toContain('//test/url-a-1.js');
-      expect(getScriptUrls()).toContain('//test/url-a-2.js');
-      expect(getScriptUrls()).toContain('//test/url-b-1.js');
-      expect(getScriptUrls()).toContain('//test/url-b-2.js');
-      spf.net.resource.unload(JS, 'b');
-      expect(getScriptUrls()).toContain('//test/url-a-1.js');
-      expect(getScriptUrls()).toContain('//test/url-a-2.js');
-      expect(getScriptUrls()).not.toContain('//test/url-b-1.js');
-      expect(getScriptUrls()).not.toContain('//test/url-b-2.js');
-      spf.net.resource.unload(JS, 'a');
-      expect(getScriptUrls()).not.toContain('//test/url-a-1.js');
-      expect(getScriptUrls()).not.toContain('//test/url-a-2.js');
-      expect(getScriptUrls()).not.toContain('//test/url-b-1.js');
-      expect(getScriptUrls()).not.toContain('//test/url-b-2.js');
-    });
-
-    it('multiple urls by name (style)', function() {
-      // Load some URLs (and check that they are "ready").
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
-      jasmine.Clock.tick(1);
-      expect(getStyleUrls()).toContain('//test/url-a-1.css');
-      expect(getStyleUrls()).toContain('//test/url-a-2.css');
-      // Remove them (and check that they are no longer "ready").
-      spf.net.resource.unload(CSS, 'a');
-      expect('//test/url-a-1.css' in spf.net.resource.status_).toBe(false);
-      expect('//test/url-a-2.css' in spf.net.resource.status_).toBe(false);
-      expect(getStyleUrls()).not.toContain('//test/url-a-1.css');
-      expect(getStyleUrls()).not.toContain('//test/url-a-2.css');
-      // Repeated calls should be no-ops.
-      spf.net.resource.unload(CSS, 'a');
-      spf.net.resource.unload(CSS, 'a');
-      expect('//test/url-a-1.css' in spf.net.resource.status_).toBe(false);
-      expect('//test/url-a-2.css' in spf.net.resource.status_).toBe(false);
-      expect(getStyleUrls()).not.toContain('//test/url-a-1.css');
-      expect(getStyleUrls()).not.toContain('//test/url-a-2.css');
-      // Check multiple names.
-      spf.net.resource.load(CSS, ['url-a-1.css', 'url-a-2.css'], 'a');
-      spf.net.resource.load(CSS, ['url-b-1.css', 'url-b-2.css'], 'b');
-      jasmine.Clock.tick(1);
-      expect(getStyleUrls()).toContain('//test/url-a-1.css');
-      expect(getStyleUrls()).toContain('//test/url-a-2.css');
-      expect(getStyleUrls()).toContain('//test/url-b-1.css');
-      expect(getStyleUrls()).toContain('//test/url-b-2.css');
-      spf.net.resource.unload(CSS, 'b');
-      expect(getStyleUrls()).toContain('//test/url-a-1.css');
-      expect(getStyleUrls()).toContain('//test/url-a-2.css');
-      expect(getStyleUrls()).not.toContain('//test/url-b-1.css');
-      expect(getStyleUrls()).not.toContain('//test/url-b-2.css');
-      spf.net.resource.unload(CSS, 'a');
-      expect(getStyleUrls()).not.toContain('//test/url-a-1.css');
-      expect(getStyleUrls()).not.toContain('//test/url-a-2.css');
-      expect(getStyleUrls()).not.toContain('//test/url-b-1.css');
-      expect(getStyleUrls()).not.toContain('//test/url-b-2.css');
     });
 
   });
@@ -463,42 +279,39 @@ describe('spf.net.resource', function() {
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Not loaded.
-      spf.net.resource.urls_['js-foo'] = ['//test/f1.js', '//test/f2.js'];
-      spf.net.resource.urls_['js-bar'] = ['//test/b.js'];
+      spf.net.resource.url.set(JS, 'foo', '//test/f.js');
+      spf.net.resource.url.set(JS, 'bar', '//test/b.js');
       spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Some loading.
-      spf.net.resource.status_['js-//test/b.js'] = LOADING;
+      spf.net.resource.status.set(LOADING, JS, '//test/b.js');
       spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // All loading.
-      spf.net.resource.status_['js-//test/b.js'] = LOADING;
-      spf.net.resource.status_['js-//test/f1.js'] = LOADING;
-      spf.net.resource.status_['js-//test/f2.js'] = LOADING;
+      spf.net.resource.status.set(LOADING, JS, '//test/b.js');
+      spf.net.resource.status.set(LOADING, JS, '//test/f.js');
       spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Some loaded, some loading.
-      spf.net.resource.status_['js-//test/b.js'] = LOADED;
-      spf.net.resource.status_['js-//test/f1.js'] = LOADING;
-      spf.net.resource.status_['js-//test/f2.js'] = LOADED;
+      spf.net.resource.status.set(LOADED, JS, '//test/b.js');
+      spf.net.resource.status.set(LOADING, JS, '//test/f.js');
       spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(1);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // All loaded.
-      spf.net.resource.status_['js-//test/b.js'] = LOADED;
-      spf.net.resource.status_['js-//test/f1.js'] = LOADED;
-      spf.net.resource.status_['js-//test/f2.js'] = LOADED;
+      spf.net.resource.status.set(LOADED, JS, '//test/b.js');
+      spf.net.resource.status.set(LOADED, JS, '//test/f.js');
       spf.net.resource.check(JS);
       expect(callbacks.one.calls.length).toEqual(1);
       expect(callbacks.two.calls.length).toEqual(1);
@@ -518,42 +331,39 @@ describe('spf.net.resource', function() {
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Not loaded.
-      spf.net.resource.urls_['css-foo'] = ['//test/f1.css', '//test/f2.css'];
-      spf.net.resource.urls_['css-bar'] = ['//test/b.css'];
+      spf.net.resource.url.set(CSS, 'foo', '//test/f.css');
+      spf.net.resource.url.set(CSS, 'bar', '//test/b.css');
       spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Some loading.
-      spf.net.resource.status_['css-//test/b.css'] = LOADING;
+      spf.net.resource.status.set(LOADING, CSS, '//test/b.css');
       spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // All loading.
-      spf.net.resource.status_['css-//test/b.css'] = LOADING;
-      spf.net.resource.status_['css-//test/f1.css'] = LOADING;
-      spf.net.resource.status_['css-//test/f2.css'] = LOADING;
+      spf.net.resource.status.set(LOADING, CSS, '//test/b.css');
+      spf.net.resource.status.set(LOADING, CSS, '//test/f.css');
       spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(0);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // Some loaded, some loading.
-      spf.net.resource.status_['css-//test/b.css'] = LOADED;
-      spf.net.resource.status_['css-//test/f1.css'] = LOADING;
-      spf.net.resource.status_['css-//test/f2.css'] = LOADED;
+      spf.net.resource.status.set(LOADED, CSS, '//test/b.css');
+      spf.net.resource.status.set(LOADING, CSS, '//test/f.css');
       spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(0);
       expect(callbacks.two.calls.length).toEqual(1);
       expect(callbacks.three.calls.length).toEqual(0);
       expect(callbacks.four.calls.length).toEqual(0);
       // All loaded.
-      spf.net.resource.status_['css-//test/b.css'] = LOADED;
-      spf.net.resource.status_['css-//test/f1.css'] = LOADED;
-      spf.net.resource.status_['css-//test/f2.css'] = LOADED;
+      spf.net.resource.status.set(LOADED, CSS, '//test/b.css');
+      spf.net.resource.status.set(LOADED, CSS, '//test/f.css');
       spf.net.resource.check(CSS);
       expect(callbacks.one.calls.length).toEqual(1);
       expect(callbacks.two.calls.length).toEqual(1);

--- a/src/client/net/script_test.js
+++ b/src/client/net/script_test.js
@@ -9,6 +9,8 @@
 
 goog.require('spf.array');
 goog.require('spf.net.resource');
+goog.require('spf.net.resource.status');
+goog.require('spf.net.resource.url');
 goog.require('spf.net.script');
 goog.require('spf.pubsub');
 goog.require('spf.state');
@@ -46,8 +48,7 @@ describe('spf.net.script', function() {
         el.src = url;
         el.className = type + '-' + url.replace(/[^\w]/g, '');
         nodes.push(el);
-        var key = type + '-' + url;
-        spf.net.resource.status_[key] = spf.net.resource.State.LOADED;
+        spf.net.resource.status.set(spf.net.resource.State.LOADED, type, url);
         opt_callback && opt_callback();
         return el;
       },
@@ -61,8 +62,7 @@ describe('spf.net.script', function() {
           return true;
         });
         nodes.splice(idx, 1);
-        var key = type + '-' + url;
-        delete spf.net.resource.status_[key];
+        spf.net.resource.status.clear(type, url);
       }
     }
   };
@@ -74,9 +74,9 @@ describe('spf.net.script', function() {
 
     spf.state.values_ = {};
     spf.pubsub.subscriptions = {};
-    spf.net.script.urls_ = {};
+    spf.net.script.url_ = {};
     spf.net.script.deps_ = {};
-    spf.net.resource.urls_ = {};
+    spf.net.resource.url_ = {};
     spf.net.resource.status_ = {};
 
     nodes = [];
@@ -103,7 +103,7 @@ describe('spf.net.script', function() {
 
   describe('load', function() {
 
-    it('passes a single url with name', function() {
+    it('passes a url with name', function() {
       var url = 'url-a.js';
       var name = 'a';
       var fn = undefined;
@@ -111,28 +111,12 @@ describe('spf.net.script', function() {
       expect(spf.net.resource.load).toHaveBeenCalledWith(JS, url, name, fn);
     });
 
-    it('passes a single url with name and callback', function() {
+    it('passes a url with name and callback', function() {
       var url = 'url-a.js';
       var name = 'a';
       var fn = function() {};
       spf.net.script.load(url, name, fn);
       expect(spf.net.resource.load).toHaveBeenCalledWith(JS, url, name, fn);
-    });
-
-    it('passes multiple urls with name', function() {
-      var urls = ['url-a-1.js', 'url-a-2.js'];
-      var name = 'a';
-      var fn = undefined;
-      spf.net.script.load(urls, name);
-      expect(spf.net.resource.load).toHaveBeenCalledWith(JS, urls, name, fn);
-    });
-
-    it('passes multiple urls with name and callback', function() {
-      var urls = ['url-a-1.js', 'url-a-2.js'];
-      var name = 'a';
-      var fn = function() {};
-      spf.net.script.load(urls, name, fn);
-      expect(spf.net.resource.load).toHaveBeenCalledWith(JS, urls, name, fn);
     });
 
   });
@@ -266,7 +250,7 @@ describe('spf.net.script', function() {
 
     it('registers completion', function() {
       spf.net.script.done('foo');
-      expect('foo' in spf.net.resource.urls_);
+      expect(spf.net.resource.url.loaded(JS, 'foo')).toBe(true);
     });
 
     it('executes callbacks', function() {

--- a/src/client/net/style_test.js
+++ b/src/client/net/style_test.js
@@ -26,7 +26,7 @@ describe('spf.net.style', function() {
 
   describe('load', function() {
 
-    it('passes a single url with name', function() {
+    it('passes a url with name', function() {
       var url = 'url-a.css';
       var name = 'a';
       var fn = undefined;
@@ -34,28 +34,12 @@ describe('spf.net.style', function() {
       expect(spf.net.resource.load).toHaveBeenCalledWith(CSS, url, name, fn);
     });
 
-    it('passes a single url with name and callback', function() {
+    it('passes a url with name and callback', function() {
       var url = 'url-a.css';
       var name = 'a';
       var fn = function() {};
       spf.net.style.load(url, name, fn);
       expect(spf.net.resource.load).toHaveBeenCalledWith(CSS, url, name, fn);
-    });
-
-    it('passes multiple urls with name', function() {
-      var urls = ['url-a-1.css', 'url-a-2.css'];
-      var name = 'a';
-      var fn = undefined;
-      spf.net.style.load(urls, name);
-      expect(spf.net.resource.load).toHaveBeenCalledWith(CSS, urls, name, fn);
-    });
-
-    it('passes multiple urls with name and callback', function() {
-      var urls = ['url-a-1.css', 'url-a-2.css'];
-      var name = 'a';
-      var fn = function() {};
-      spf.net.style.load(urls, name, fn);
-      expect(spf.net.resource.load).toHaveBeenCalledWith(CSS, urls, name, fn);
     });
 
   });

--- a/src/client/state.js
+++ b/src/client/state.js
@@ -75,9 +75,9 @@ spf.state.Key = {
   PUBSUB_SUBS: 'ps-s',
   RESOURCE_PATHS_PREFIX: 'rsrc-p-',
   RESOURCE_STATUS: 'rsrc-s',
-  RESOURCE_URLS: 'rsrc-u',
+  RESOURCE_URL: 'rsrc-u',
   SCRIPT_DEPS: 'js-d',
-  SCRIPT_URLS: 'js-u',
+  SCRIPT_URL: 'js-u',
   TASKS_UID: 'uid'
 };
 


### PR DESCRIPTION
This follows up on the previous API change that allowed only one URL per name
during script/style loading and transitions the underlying implementation to
match the API.

Progress on #25.
