### PR TITLE
Handle edge cases for script/style loading.

### DIFF
--- a/src/client/pubsub/pubsub.js
+++ b/src/client/pubsub/pubsub.js
@@ -108,6 +108,25 @@ spf.pubsub.publish_ = function(topic, opt_unsub) {
 
 
 /**
+ * Renames a topic.  All functions subscribed to the old topic will then
+ * be subscribed to the new topic instead.
+ *
+ * @param {string} oldTopic The old name for the topic. Passing an empty string
+ *     does nothing.
+ * @param {string} newTopic The new name for the topic. Passing an empty string
+ *     does nothing.
+ */
+spf.pubsub.rename = function(oldTopic, newTopic) {
+  if (oldTopic && newTopic && oldTopic in spf.pubsub.subscriptions) {
+    var existing = spf.pubsub.subscriptions[newTopic] || [];
+    spf.pubsub.subscriptions[newTopic] =
+        existing.concat(spf.pubsub.subscriptions[oldTopic]);
+    spf.pubsub.clear(oldTopic);
+  }
+};
+
+
+/**
  * Clears the subscription list for a topic.
  *
  * @param {string} topic Topic to clear.

--- a/src/client/pubsub/pubsub_test.js
+++ b/src/client/pubsub/pubsub_test.js
@@ -114,6 +114,24 @@ describe('spf.pubsub', function() {
     expect(callbacks.two.calls.length).toEqual(1);
   });
 
+  it('rename', function() {
+    // Subscribe.
+    spf.pubsub.subscribe('foo', callbacks.one);
+    spf.pubsub.subscribe('foo', callbacks.two);
+    spf.pubsub.publish('foo');
+    expect(callbacks.one.calls.length).toEqual(1);
+    expect(callbacks.two.calls.length).toEqual(1);
+    // Rename.
+    spf.pubsub.rename('foo', 'bar');
+    spf.pubsub.publish('bar');
+    expect(callbacks.one.calls.length).toEqual(2);
+    expect(callbacks.two.calls.length).toEqual(2);
+    expect(subs['foo'] || []).not.toContain(callbacks.one);
+    expect(subs['foo'] || []).not.toContain(callbacks.two);
+    expect(subs['bar'] || []).toContain(callbacks.one);
+    expect(subs['bar'] || []).toContain(callbacks.two);
+  });
+
   it('clear', function() {
     spf.pubsub.subscribe('bar', callbacks.three);
     spf.pubsub.subscribe('bar', callbacks.four);

--- a/src/client/state.js
+++ b/src/client/state.js
@@ -73,6 +73,7 @@ spf.state.Key = {
   NAV_REQUEST: 'nav-request',
   PREFETCH_LISTENER: 'prefetch-listener',
   PUBSUB_SUBS: 'ps-s',
+  RESOURCE_NAME: 'rsrc-n',
   RESOURCE_PATHS_PREFIX: 'rsrc-p-',
   RESOURCE_STATUS: 'rsrc-s',
   RESOURCE_URL: 'rsrc-u',


### PR DESCRIPTION
The edge cases handled are:
- Ensure switching names for an existing URL works.
- Ensure callbacks are transfered when switching names for existing URLs.
- Ensure switching URLs cancels previous callbacks.
- Ensure calling unload cancels previous callbacks.

Add tests for all of the above.

Closes #60.
