### PR TITLE
Website: Rename the "nav" Jekyll plugin to "sitenav".

### DIFF
--- a/web/_data/sitenav.yml
+++ b/web/_data/sitenav.yml
@@ -3,7 +3,7 @@
 # Use of this source code is governed by The MIT License.
 # See the LICENSE file for details.
 
-# This data file is used by the nav plugin to build a tree for navigation.
+# This data file is used by the sitenav plugin to build a site navigation tree.
 #
 # Required:
 #   path - the path component of the nav item

--- a/web/_includes/nav.liquid
+++ b/web/_includes/nav.liquid
@@ -1,8 +1,8 @@
-{% assign nav__list = site.data.nav %}
+{% assign sitenav__list = site.data.sitenav %}
 <ul>
-  {% for nav__item in nav__list %}
-    <li {% if nav__item.url == "/" %}class="index"{% endif %}>
-      <a href="{{ site.baseurl }}{{ nav__item.page.url | replace:'index.html','' }}">{{ nav__item.page.title }}</a>
+  {% for sitenav__item in sitenav__list %}
+    <li {% if sitenav__item.url == "/" %}class="index"{% endif %}>
+      <a href="{{ site.baseurl }}{{ sitenav__item.page.url | replace:'index.html','' }}">{{ sitenav__item.page.title }}</a>
     </li>
   {% endfor %}
 </ul>

--- a/web/_includes/toc.liquid
+++ b/web/_includes/toc.liquid
@@ -1,5 +1,5 @@
 {% if include.path %}
-  {% assign toc__top = site.data.navindex[include.path] %}
+  {% assign toc__top = site.data.sitenav_index[include.path] %}
   {% assign toc__list = toc__top.sub %}
   {% if include.title %}
     <p class="toc__title">
@@ -7,7 +7,7 @@
     </p>
   {% endif %}
 {% else %}
-  {% assign toc__list = site.data.nav %}
+  {% assign toc__list = site.data.sitenav %}
 {% endif %}
 <ol class="toc__list list-links">
   {% for toc__item in toc__list %}

--- a/web/_layouts/documentation.liquid
+++ b/web/_layouts/documentation.liquid
@@ -20,7 +20,7 @@ layout: base
         {% endif %}
       </header>
       {% assign guide__path = page.url | replace:'index.html','' %}
-      {% assign guide__list = site.data.navindex[guide__path].sub %}
+      {% assign guide__list = site.data.sitenav_index[guide__path].sub %}
       <ol class="guides-list container">
         {% for guide__item in guide__list %}
           <li class="guides-list__item g--half theme--spf">

--- a/web/_plugins/sitenav.rb
+++ b/web/_plugins/sitenav.rb
@@ -3,7 +3,7 @@
 # Use of this source code is governed by The MIT License.
 # See the LICENSE file for details.
 
-# Jekyll plugin to build site navigation tree from directory layout.
+# Jekyll plugin to build a site navigation tree from directory layout.
 #
 # Author:: nicksay@google.com (Alex Nicksay)
 
@@ -11,7 +11,7 @@
 module Jekyll
 
 
-  class NavIndexPage < Page
+  class SiteNavIndexPage < Page
 
     def initialize(site, base, dir, item)
       @site = site
@@ -39,22 +39,22 @@ module Jekyll
   end
 
 
-  class NavGenerator < Generator
+  class SiteNavGenerator < Generator
 
-    def link(nav, pages, index, prefix, site)
-      nav.each do |item|
+    def link(sitenav, pages, index, prefix, site)
+      sitenav.each do |item|
         url = [prefix, item['path']].join('/').gsub('//', '/')
         item['url'] = url
-        # For navigation directories, create empty index pages if needed.
+        # For directories, create empty index pages if needed.
         if url.end_with?('/') and not pages.has_key?(url)
-          index_page = NavIndexPage.new(site, site.source, url, item)
+          index_page = SiteNavIndexPage.new(site, site.source, url, item)
           site.pages << index_page
           pages[url] = index_page
           index_page.data['original_layout'] = index_page.data['layout']
         end
-        # Link nav item -> page.
+        # Link item -> page.
         item['page'] = pages[url]
-        # Link url -> nav item.
+        # Link url -> item.
         index[url] = item
         if item.key?('sub')
           self.link(item['sub'], pages, index, url, site)
@@ -70,8 +70,8 @@ module Jekyll
         page.data['original_layout'] = page.data['layout']
       end
       index = {}
-      self.link(site.data['nav'], pages, index, '', site)
-      site.data['navindex'] = index
+      self.link(site.data['sitenav'], pages, index, '', site)
+      site.data['sitenav_index'] = index
     end
 
   end


### PR DESCRIPTION
This makes searching for the plugin easier and helps communicate
that the plugin provides builds an index that is both for navigation
and that is a sitemap.
