### PR TITLE
Support configurable persistent parameters.

### DIFF
--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -266,6 +266,7 @@ spf.nav.handleClick_ = function(evt) {
   if (!url) {
     return;
   }
+  url = spf.url.appendPersistentParameters(url);
   // Ignore clicks if the URL is not allowed (e.g. cross-domain).
   if (!spf.nav.isAllowed_(url)) {
     return;
@@ -338,6 +339,8 @@ spf.nav.handleHistory_ = function(url, opt_state) {
     return;
   }
   // Navigate to the URL.
+  // NOTE: The persistent parameters are not appended here because they should
+  // already be set on the URL if necessary.
   spf.nav.navigate_(url, null, current, referer, true, reverse);
 };
 
@@ -362,6 +365,7 @@ spf.nav.navigate = function(url, opt_options) {
   if (!url) {
     return;
   }
+  url = spf.url.appendPersistentParameters(url);
   // Reload if the URL is not allowed (e.g. cross-domain).
   if (!spf.nav.isAllowed_(url)) {
     spf.nav.reload(url, spf.nav.ReloadReason.FORBIDDEN);
@@ -878,6 +882,7 @@ spf.nav.reload = function(url, reason, opt_err) {
  * @param {spf.RequestOptions=} opt_options Optional request options object.
  */
 spf.nav.load = function(url, opt_options) {
+  url = spf.url.appendPersistentParameters(url);
   spf.nav.load_(url, opt_options);
 };
 
@@ -936,6 +941,7 @@ spf.nav.load_ = function(url, opt_options, opt_original) {
  * @param {spf.RequestOptions=} opt_options Optional request options object.
  */
 spf.nav.prefetch = function(url, opt_options) {
+  url = spf.url.appendPersistentParameters(url);
   spf.nav.prefetch_(url, opt_options);
 };
 

--- a/src/client/url/url.js
+++ b/src/client/url/url.js
@@ -193,6 +193,25 @@ spf.url.removeParameters = function(url, parameters) {
 
 
 /**
+ * Appends a configurable set of parameters that should persist across URLs.
+ *
+ * @param {string} url A URL.
+ * @return {string} A new URL with the persistent parameters included.
+ */
+spf.url.appendPersistentParameters = function(url) {
+  // Get the param config of the form "abc=def&foo=bar"
+  var parameterConfig = spf.config.get('advanced-persistent-parameters') || '';
+  var result = spf.string.partition(url, '#');
+  url = result[0];
+  var delim = spf.string.contains(url, '?') ? '&' : '?';
+  // Append the persistent parameters to the URL.
+  url += parameterConfig ? delim + parameterConfig : '';
+  // Reattach the hash.
+  return url + result[1] + result[2];
+};
+
+
+/**
  * Converts an absolute URL to protocol-relative (e.g. no http: or https:).
  * Has no effect on relative URLs.
  *

--- a/src/client/url/url_test.js
+++ b/src/client/url/url_test.js
@@ -108,6 +108,63 @@ describe('spf.url', function() {
 
   });
 
+  describe('appendPersistentParameters', function() {
+
+    it('does nothing without a config', function() {
+      var url = '/page';
+      expect(spf.url.appendPersistentParameters(url)).toEqual('/page');
+    });
+
+    it('appends params with a config', function() {
+      var url = '/page';
+      spf.config.set('advanced-persistent-parameters', 'abc=def');
+      expect(spf.url.appendPersistentParameters(url)).toEqual('/page?abc=def');
+
+      url = '/page?param=123';
+      expect(spf.url.appendPersistentParameters(url)).toEqual(
+          '/page?param=123&abc=def');
+
+      url = '/page';
+      spf.config.set('advanced-persistent-parameters', 'abc=def&foo=bar');
+      expect(spf.url.appendPersistentParameters(url)).toEqual(
+          '/page?abc=def&foo=bar');
+
+      url = '/page?param=123';
+      expect(spf.url.appendPersistentParameters(url)).toEqual(
+          '/page?param=123&abc=def&foo=bar');
+    });
+
+    it('supports partial params', function() {
+      var url = '/page';
+      spf.config.set('advanced-persistent-parameters', 'abc');
+      expect(spf.url.appendPersistentParameters(url)).toEqual('/page?abc');
+
+      spf.config.set('advanced-persistent-parameters', 'abc=def&foo');
+      expect(spf.url.appendPersistentParameters(url)).toEqual(
+          '/page?abc=def&foo');
+    });
+
+    it('supports duplicate params', function() {
+      var url = '/page';
+      spf.config.set('advanced-persistent-parameters', 'abc=def&abc=ghi');
+      expect(spf.url.appendPersistentParameters(url)).toEqual(
+          '/page?abc=def&abc=ghi');
+    });
+
+    it('respects hashes', function() {
+      var url = '/page#frag';
+      spf.config.set('advanced-persistent-parameters', 'abc=def');
+      expect(spf.url.appendPersistentParameters(url)).toEqual(
+          '/page?abc=def#frag');
+
+      url = '/page?param=123#frag';
+      spf.config.set('advanced-persistent-parameters', 'abc=def');
+      expect(spf.url.appendPersistentParameters(url)).toEqual(
+          '/page?param=123&abc=def#frag');
+    });
+
+  });
+
   describe('unprotocol', function() {
 
     it('absolute', function() {


### PR DESCRIPTION
New advanced config option `advanced-persistent-parameters`. When set, URLs are modified to include the parameters.

Parameters are appended prior to loads and prefetches in addition to navigations. The format of the config should be "abc=def&foo=bar" without a leading "?". The leading delimeter is determined at runtime based on the presence of params on the given URL.

Closes #134
