### PR TITLE
Use real DOM for testing (1 of 2).

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -131,7 +131,7 @@ def find_js_sources():
 
 
 def find_js_tests():
-  tests = []
+  tests = ['src/client/testing/dom.js']
   for root, dirs, files in os.walk('src/client'):
     for file in files:
       if file.endswith('test.js'):

--- a/src/client/nav/response_test.js
+++ b/src/client/nav/response_test.js
@@ -12,6 +12,7 @@ goog.require('spf.dom');
 goog.require('spf.history');
 goog.require('spf.nav.response');
 goog.require('spf.string');
+goog.require('spf.testing.dom');
 
 
 describe('spf.nav.response', function() {
@@ -516,40 +517,20 @@ describe('spf.nav.response', function() {
   describe('process', function() {
 
     var currentUrl = 'http://www.youtube.com/watch?v=1';
-    var elements = {};
-
-    var FakeElement = function(initialHTML, initialAttributes) {
-      this.attributes = {};
-      this.className = '';
-      this.innerHTML = initialHTML || '';
-      if (initialAttributes) {
-        spf.dom.setAttributes(this, initialAttributes);
-      }
-    };
-    FakeElement.prototype.getAttribute = function(name) {
-      return this.attributes[name];
-    };
-    FakeElement.prototype.setAttribute = function(name, value) {
-      this.attributes[name] = value;
-    };
 
     beforeEach(function() {
       spyOn(spf.nav.response, 'getCurrentUrl_').andReturn(currentUrl);
       spyOn(spf.history, 'replace');
-      spyOn(document, 'getElementById').andCallFake(function(id) {
-        return elements[id];
-      });
     });
 
     afterEach(function() {
-      elements = {};
+      spf.testing.dom.removeAllElements();
     });
 
     it('sets attributes from "attr" field', function() {
-      elements = {
-        'foo': new FakeElement({'class': 'first'}),
-        'bar': new FakeElement({'dir': 'ltr'})
-      };
+      var foo = spf.testing.dom.createElement('foo', undefined,
+          {'class': 'first'});
+      var bar = spf.testing.dom.createElement('bar', undefined, {'dir': 'ltr'});
 
       var response = {
         'attr': {
@@ -559,17 +540,15 @@ describe('spf.nav.response', function() {
       };
 
       spf.nav.response.process('/page', response, null, true);
-      expect(elements['foo'].className).toEqual('last');
-      expect(elements['foo'].attributes['dir']).toEqual('rtl');
-      expect(elements['bar'].className).toEqual('last');
-      expect(elements['bar'].attributes['dir']).toEqual('rtl');
+      expect(foo.className).toEqual('last');
+      expect(foo.getAttribute('dir')).toEqual('rtl');
+      expect(bar.className).toEqual('last');
+      expect(bar.getAttribute('dir')).toEqual('rtl');
     });
 
     it('sets html from "body" field', function() {
-      elements = {
-        'foo': new FakeElement('one'),
-        'bar': new FakeElement()
-      };
+      var foo = spf.testing.dom.createElement('foo', 'one');
+      var bar = spf.testing.dom.createElement('bar');
 
       var response = {
         'body': {
@@ -579,8 +558,8 @@ describe('spf.nav.response', function() {
       };
 
       spf.nav.response.process('/page', response, null, true);
-      expect(elements['foo'].innerHTML).toEqual('two');
-      expect(elements['foo'].innerHTML).toEqual('two');
+      expect(foo.innerHTML).toEqual('two');
+      expect(bar.innerHTML).toEqual('two');
     });
 
     it('updates history for navigate with redirect url', function() {

--- a/src/client/testing/dom.js
+++ b/src/client/testing/dom.js
@@ -1,0 +1,58 @@
+// Copyright 2014 Google Inc. All rights reserved.
+//
+// Use of this source code is governed by The MIT License.
+// See the LICENSE file for details.
+
+/**
+ * @fileoverview Helper functions for tests that use the DOM.
+ *
+ * @author rviscomi@google.com (Rick Viscomi)
+ */
+
+goog.provide('spf.testing.dom');
+
+goog.require('spf.dom');
+
+
+/**
+ * Unique identifier for SPF test element tag names.
+ *
+ * @const {string}
+ */
+spf.testing.dom.TAG_NAME = 'spftest';
+
+
+/**
+ * Creates a DOM element prepopulated with test data.
+ *
+ * @param {string} id The element's unique ID.
+ * @param {string=} opt_initialHTML Optional inner HTML of the element.
+ * @param {Object.<string>=} opt_initialAttributes Optional attributes to set
+ *   on the element.
+ * @return {Element} The newly-created test element.
+ */
+spf.testing.dom.createElement = function(id, opt_initialHTML,
+    opt_initialAttributes) {
+  var element = document.createElement(spf.testing.dom.TAG_NAME);
+  element.id = id;
+  element.innerHTML = opt_initialHTML || '';
+  if (opt_initialAttributes) {
+    spf.dom.setAttributes(element, opt_initialAttributes);
+  }
+  document.body.appendChild(element);
+  return element;
+};
+
+
+/**
+ * Removes all elements with the unique test tag name.
+ * See {@link #createElement}.
+ */
+spf.testing.dom.removeAllElements = function() {
+  var elements = document.getElementsByTagName(spf.testing.dom.TAG_NAME);
+  // `elements` is a live node list. Removing one of these elements from the DOM
+  // also removes it from the array.
+  while (elements.length) {
+    document.body.removeChild(elements[0]);
+  }
+};


### PR DESCRIPTION
New JS library `spf.testing.dom` appends elements to the document to be used in SPF tests.

Use this on response_test. Next and final part is to change resource_test.

Progress on #178
