### PR TITLE
Update name script to support import as a module.

### DIFF
--- a/bin/calcdeps.js
+++ b/bin/calcdeps.js
@@ -498,7 +498,7 @@ cli.help = function() {
 /**
  * The main execution function.
  */
-function main(args, opts) {
+function main(opts, args) {
   if (cli.active) {
     // If this is a command-line invocation, parse the args and opts.  If the
     // args are missing or the help opt is given, print the help and exit.

--- a/bin/configure.js
+++ b/bin/configure.js
@@ -181,8 +181,8 @@ function targets(ninja) {
   // Find source files.
   var opts = {path: ['src/client/', 'third-party/']};
   var srcs = {
-    main: $.calcdeps('ns:spf.main', opts),
-    bootloader: $.calcdeps('ns:spf.bootloader', opts)
+    main: $.calcdeps(opts, 'ns:spf.main'),
+    bootloader: $.calcdeps(opts, 'ns:spf.bootloader')
   };
   // Prepend the stub file since Closure Library isn't used.
   srcs.main.unshift('src/client/stub.js');


### PR DESCRIPTION
Allow importing the `name` script as a Node module for use by other scripts.
The module API follows that of the command line exactly.

Progress on #7.
