### PR TITLE
Port configure script to Node, step 2: build JS tests.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
     "node_modules"
   ],
   "devDependencies": {
-    "closure-compiler": "http://dl.google.com/closure-compiler/compiler-20140625.zip"
+    "closure-compiler": "http://dl.google.com/closure-compiler/compiler-20140625.zip",
+    "jasmine": "https://github.com/pivotal/jasmine/raw/ea76a30d85218954625d4685b246218d9ca2dfe1/dist/jasmine-standalone-1.3.1.zip"
   }
 }


### PR DESCRIPTION
This is step 2 of porting our configure script to Node.  This version improves
on the previous by directly linking all source files to avoid needing to
recompile when writing/running tests.

Progress on #7.
