### PR TITLE
Port configure script to Node, step 3: run JS tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "minimist": "^1.1.0",
     "ninja-build": "^0.1.5",
     "ninja-build-gen": "^0.1.3",
+    "phantomjs": "^1.9.12",
     "semver": "^4.1.0",
     "wordwrap": "0.0.2"
   }


### PR DESCRIPTION
This is step 3 of porting our configure script to Node.  Now that the
PhantomJS dependency can be managed well, this version improves on the previous
by adding a `test` target that runs the tests on the command line.  Generating
the tests for running in a browser is still done by the `tests` target.

Progress on #7.
