### PR TITLE
Build with Node, part 1: run Ninja via npm scripts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
-language: python
-python:
-  - "2.7"
+language: node_js
+  - 0.10
 install:
-  - easy_install http://closure-linter.googlecode.com/files/closure_linter-latest.tar.gz
+  - npm install
 before_script:
-  - make
-  - make tests
-  - make lint
+  - npm run build
+  - npm run lint
 script:
-  phantomjs build/test/run-jasmine.js build/test/runner.html
+  - npm test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,25 @@
   "bugs": {
     "url": "https://github.com/youtube/spfjs/issues"
   },
+  "scripts": {
+    "prepublish": "bower install && bin/configure.js",
+    "build": "ninja",
+    "build-all": "ninja all",
+    "build-spf": "ninja spf spf-debug spf-trace",
+    "build-boot": "ninja boot boot-debug boot-trace",
+    "build-dev": "ninja dev",
+    "build-tests": "ninja tests",
+    "build-demo": "ninja demo",
+    "dist": "ninja dist",
+    "test": "ninja test",
+    "lint": "ninja lint",
+    "fix": "ninja fix",
+    "start": "ninja demo && cd build/demo && python -m app",
+    "clean": "rm -rf build build.ninja dist",
+    "reset": "npm run clean; rm -rf bower_components node_modules vendor"
+  },
   "devDependencies": {
+    "bower": "^1.3.12",
     "closure-linter-wrapper": "^0.2.9",
     "glob": "^4.3.1",
     "minimist": "^1.1.0",


### PR DESCRIPTION
This change adds npm scripts for the major build tasks, providing equivalent
functionality to the existing Make targets:
- prepublish: ensure deps are downloaded and build file generated
- build: build default (spf.js)
- build-spf: build spf files (spf.js, spf-debug.js spf-trace.js)
- build-boot: build bootloader files (boot.js, boot-debug.js, boot-trace.js)
- build-dev: build development file (dev-spf-bundle.js)
- build-tests: build test runner and tests
- build-demo: build demo app
- build-all: build all
- dist: create distribution files
- test: run tests
- lint: lint files for style/formatting
- fix: automatically fix style/formatting of files
- start: run demo app
- clean: delete built files
- reset: delete built files and downloaded deps (get to newly-cloned state)

This change also updates the Travis CI configuration to use the above.

Progress on #7.
