### PR TITLE
Improve README with a banner, download links, and improved wording.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,219 +1,159 @@
-# [SPF](http://youtube.github.io/spfjs/)
+# [![SPF](https://youtube.github.io/spfjs/assets/images/banner-728x388.jpg)](https://youtube.github.io/spfjs/)
 [![NPM Version](https://badge.fury.io/js/spf.svg)](http://badge.fury.io/js/spf)
-[![Build Status](https://secure.travis-ci.org/youtube/spfjs.png?branch=master)](http://travis-ci.org/youtube/spfjs)
+[![Build Status](https://secure.travis-ci.org/youtube/spfjs.svg?branch=master)](http://travis-ci.org/youtube/spfjs)
 
-Structured Page Fragments — or SPF for short — is a lightweight framework that
-handles navigation and updates of page sections. Using progressive
-enhancement and HTML5, SPF seamlessly updates pages with server-side rendering.
-Only document fragments are sent, and corresponding page sections are
-asynchronously updated when received.
+Structured Page Fragments — or SPF for short — is a lightweight JS framework for
+fast navigation and page updates from YouTube.
+
+Using progressive enhancement and HTML5, SPF integrates with your site to enable
+a faster, more fluid user experience by updating just the sections of the page
+that change during navigation, not the whole page.  SPF provides a response
+format for sending document fragments, a robust system for script and style
+management, an in-memory cache, on-the-fly processing, and more.
+
+**Learn more at [youtube.github.io/spfjs](https://youtube.github.io/spfjs/)**
 
 
 ## Overview
 
-When someone first arrives at a site, content is sent from the server and
-rendered normally.  This is _static_ navigation.  But when going to the next
-page, only document fragments are sent, and sections are updated accordingly.
-We call this _dynamic_ navigation.  The basic navigation flow is:
+SPF allows you to leverage the benefits of a static initial page load, while
+gaining the performance and user experience benefits of dynamic page loads:
 
-1. Client handles click; adds history.
-2. Client requests fragments.
-3. Server responds with fragments.
-4. Client updates page.
+**User Experience**  
+1. Get the fastest possible initial page load.  
+2. Keep a responsive persistent interface during navigation.  
 
+**Performance**  
+1. Leverage existing techniques for static rendering.  
+2. Load small responses and fewer resources each navigation.  
 
-## Benefits
-
-SPF allows you to leverage the benefits of an initial page load using static
-navigation, while gaining the performance and user experience benefits of
-dynamic rendering for subsequent pages.
-
-User Experience:
-
-* Fastest possible first page rendering
-* Persistent interface stays responsive during navigation
-
-Performance:
-
-* Leverage existing web performance techniques for static rendering
-* Subsequent responses are smaller
-* Scripts and styles are already loaded for the next navigation
-
-Development:
-
-* Maintain productivity using the same code for static and dynamic rendering
-* Use any server-side language and any template system
-* Send data for use with a client-side system
+**Development**  
+1.  Use any server-side language and template system.  
+2.  Be productive by using the same code for static and dynamic rendering.  
 
 
-## Features
+## Download
 
-SPF has additional, optional features you can use to improve your site.
+The most recent release is **SPF 20 (v2.0.1)**.
 
-**Caching:** In some web apps, HTTP caching isn't appropriate.  SPF allows you
-to cache responses in client memory according to your application-specific
-parameters.
+> [Download SPF](https://github.com/youtube/spfjs/releases/download/v2.0.1/spfjs-2.0.1-dist.zip)
 
-**Prefetching:** Make requests early, automatically or manually, to predictively
-boost performance with instant access to future pages.
+Link to the minified JS from a CDN:
 
-**Multipart:** SPF supports streaming multipart responses in chunks to enable
-on-the-fly processing.  This speeds up navigation by starting rendering early.
+```html
+<script src="https://ajax.googleapis.com/ajax/libs/spf/2.0.1/spf.js">
+</script>
+```
+
+Or, install with [npm](https://www.npmjs.com/) or [Bower](http://bower.io/):
+
+
+```sh
+npm install spf@2.0.1
+```
+
+```sh
+bower install spf#2.0.1
+```
+
+See [the download page](http://youtube.github.io/spfjs/download/) for more
+options.
+
 
 
 ## Get Started
 
-SPF has no dependencies and is a single standalone file.  It is only ~9K when
-minified and gzipped, and it may be asynchronously delay-loaded.
+The SPF client library is a single ~10K [UMD](https://github.com/umdjs/umd) JS
+file with no dependencies.  It may be asynchronously delay-loaded.  All
+functions are exposed via the global `spf` object.
 
-To get started, clone the project, checkout the latest release, and copy the
-SPF release file where you serve JS files for your site:
+**Enable SPF**
 
-```shell
-git clone https://github.com/youtube/spfjs.git
-cd spfjs
-git checkout `git tag --list | tail -n 1`
-cp dist/spf.js YOUR_JS_DIR/
-```
-
-Then, add the script to your page and initialize SPF:
+To add SPF to your site, include the JS file and run `spf.init()`.
 
 ```html
-<script src="spf.js"></script>
 <script>
   spf.init();
 </script>
 ```
 
-
-## Client-Side Implementation
+**Send requests**
 
 SPF does not change your site's navigation automatically and instead uses
 progressive enhancement to enable dynamic navigation for certain links.  Just
-add a `spf-link` class to `<a>` tags or their containers to activate SPF:
+add a `spf-link` class to an `<a>` tag to activate SPF.
 
-Static Navigation:
+Go from static navigation:
 
 ```html
 <a href="/destination">Go!</a>
-
-<ul>
-  <li><a href="/option/one">Menu item 1</a></li>
-  <li><a href="/option/two">Menu item 2</a></li>
-</ul>
 ```
 
-
-Dynamic Navigation:
+to dynamic navigation:
 
 ```html
+<!-- Link enabled: a SPF request will be sent -->
 <a class="spf-link" href="/destination">Go!</a>
-
-<ul class="spf-link">
-  <li><a href="/option/one">Menu item 1</a></li>
-  <li><a href="/option/two">Menu item 2</a></li>
-</ul>
 ```
 
-When an enabled link is clicked, SPF will handle the history and request the
-fragments for the destination link.
-
-
-## Server-Side Implementation
+**Return responses**
 
 In static navigation, an entire HTML page is sent.  In dynamic navigation, only
 fragments are sent, using JSON as transport.  When SPF sends a request to the
-server, it appends an identifier `?spf=navigate` so that you can properly
-handle the request.
+server, it appends a configurable identifier to the URL so that your server can
+properly handle the request.  (By default, this will be `?spf=navigate`.)
 
 In the following example, a common layout of upper masthead, middle content, and
 lower footer is used.  In dynamic navigation, only the fragment for the middle
 content is sent, since the masthead and footer don't change.
 
-Static Navigation:  `GET /destination`
+Go from static navigation:
+
+`GET /destination`
 
 ```html
 <html>
- <head>
-  <!-- Styles -->
- </head>
- <body>
-  <div id="masthead">...</div>
-  <div id="content">
-    <!-- Content -->
-  </div>
-  <div id="footer">...</div>
-  <!-- Scripts -->
- </body>
+  <head>
+    <!-- Styles -->
+  </head>
+  <body>
+    <div id="masthead">...</div>
+    <div id="content">
+      <!-- Content -->
+    </div>
+    <div id="footer">...</div>
+    <!-- Scripts -->
+  </body>
 </html>
 ```
 
-Dynamic Navigation:  `GET /destination?spf=navigate`
+to dynamic navigation:
+
+`GET /destination?spf=navigate`
 
 ```json
 {
- "head": "<!-- Styles -->",
- "body": {
-  "content":
-    "<!-- Content -->",
- },
- "foot": "<!-- Scripts -->"
+  "head": "<!-- Styles -->",
+  "body": {
+    "content":
+        "<!-- Content -->",
+  },
+  "foot": "<!-- Scripts -->"
 }
 ```
 
-
-## Response Processing
-
-SPF responses are processed in the following order (all fields are optional):
-
-1. `title` — Update document title
-2. `url` — Update document url
-3. `head` — Install early page-wide styles
-4. `attr` — Set element attributes
-5. `body` — Set element content and install element-level scripts
-            (styles handled by browser)
-6. `foot` — Install late page-wide scripts
-
-The commonly needed response values are `title`, `head`, `body`, and `foot`,
-in the following general format:
-
-```json
-{
-    "title": "Document Title",
-    "head":  "<style>CSS Text</style>
-             <link rel=\"stylesheet\" type=\"text/css\" href=\"CSS URL\">
-             ...",
-    "body":  {  "DOM ID 1": "HTML Text...",
-                "DOM ID 2": "..."
-             },
-    "foot":  "<script>JS Text</script>
-             <script src=\"JS URL\"></script>
-             ..."
-}
-```
-
-This pattern follows the general good practice of "styles in the head, scripts
-at the end of the body".  The "foot" field represents the "end of the body"
-section without requiring developers to create an explicit element.
-
-To update specific element attributes, the response format is as follows:
-
-```json
-{
-      "attr":  {  "DOM ID 1":  {  "Name 1": "Value 1",
-                                  "Name 2": "Value 2"
-                               },
-                  "DOM ID 2":  {  "...": "..."  }
-               }
-}
-```
+See [the documentation](http://youtube.github.io/spfjs/documentation/) for
+complete information.
 
 
 ## Get Help
 
-**We're actively working on our documentation!**  More information, examples,
-and a website is coming soon.  Don't hesitate to reach out to us via our
-[mailing list](https://groups.google.com/forum/#!forum/spfjs) and follow
+Send feedback, comments, or questions about SPF to <spfjs@googlegroups.com>.
+
+File bugs or feature requests at
+[GitHub](https://github.com/youtube/spfjs/issues).
+
+Join our [mailing list](https://groups.google.com/group/spfjs) and follow
 [@spfjs](https://twitter.com/spfjs) on Twitter for updates.
 
 


### PR DESCRIPTION
- Add a banner image to the top of the file
- Use SVG badges
- Improve the description of the framework
- Add a Download section with links to release files and npm/Bower
- Streamline the Overview and Benefits sections
- Bring the Get Started and Get Help sections in line with the website
- Remove the Response Processing section in favor of the website version

Closes #216.
