### PR TITLE
Website: use SPF for the SPF site, part 2 - enable transitions.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "jasmine": "https://github.com/pivotal/jasmine/raw/ea76a30d85218954625d4685b246218d9ca2dfe1/dist/jasmine-standalone-1.3.1.zip",
     "webpy": "https://github.com/webpy/webpy/archive/73f1119649ffe54ba26ddaf6a612aaf1dab79b7f.zip",
     "web-starter-kit": "~0.4.0",
-    "octicons": "~2.1.2"
+    "octicons": "~2.1.2",
+    "spf": "2.1.1"
   }
 }

--- a/web/Rakefile
+++ b/web/Rakefile
@@ -3,114 +3,79 @@
 # Use of this source code is governed by The MIT License.
 # See the LICENSE file for details.
 
-require 'fileutils'
-require 'sass'
-require 'autoprefixer-rails'
+require "fileutils"
+require "json"
+require "sass"
+require "autoprefixer-rails"
 
 
 SITE = "_site"
-STAGING_AREA = "../../spfjs-gh-pages"
+STAGING = "../../spfjs-gh-pages"
+VENDOR = "../bower_components"
+LOCAL = "assets/vendor"
 
-LOCAL_WSK = "assets/vendor"
-LOCAL_IMAGES = "#{LOCAL_WSK}/images"
-LOCAL_STYLES = "#{LOCAL_WSK}/styles"
+BOWER_INFO = JSON.parse(`cd .. && bower --offline list --json`)["dependencies"]
 
-WSK = "../bower_components/web-starter-kit"
-WSK_IMAGES = "#{WSK}/app/images"
-WSK_STYLES = "#{WSK}/app/styles"
+# Use an official SPF release instead of building from source.
+SPF = "#{VENDOR}/spf"
+SPF_VERSION = BOWER_INFO["spf"]["pkgMeta"]["_release"]
+LOCAL_SPF = "#{LOCAL}/spf/#{SPF_VERSION}"
 
-OCTICONS = "../bower_components/octicons/octicons"
+WSK = "#{VENDOR}/web-starter-kit/app"
+WSK_VERSION = BOWER_INFO["web-starter-kit"]["pkgMeta"]["_release"]
+LOCAL_WSK = "#{LOCAL}/wsk/#{WSK_VERSION}"
+
+OCTICONS = "#{VENDOR}/octicons/octicons"
+OCTICONS_VERSION = BOWER_INFO["octicons"]["pkgMeta"]["_release"]
+LOCAL_OCTICONS = "#{LOCAL}/octicons/#{OCTICONS_VERSION}"
 
 AUTOPREFIXER_BROWSERS = [
-  'ie >= 10',
-  'ie_mob >= 10',
-  'ff >= 30',
-  'chrome >= 34',
-  'safari >= 7',
-  'opera >= 23',
-  'ios >= 7',
-  'android >= 4.4',
-  'bb >= 10'
+  "ie >= 10",
+  "ie_mob >= 10",
+  "ff >= 30",
+  "chrome >= 34",
+  "safari >= 7",
+  "opera >= 23",
+  "ios >= 7",
+  "android >= 4.4",
+  "bb >= 10",
 ]
 
 
-# The local WSK css file depends on all the WSK inputs.
-CSS_OUT_WSK = "#{LOCAL_STYLES}/wsk.css"
-wsk_css_files = [
-  "#{WSK_STYLES}/h5bp.css",
-  "#{WSK_STYLES}/components/components.css",
-  "#{WSK_STYLES}/main.css",
-]
-wsk_css_files.each do |src|
-  file CSS_OUT_WSK => src
-end
-file CSS_OUT_WSK do
-  css = ""
-  # Concatenate WSK files.
-  wsk_css_files.each do |wsk_css_file|
-    css += File.read(wsk_css_file)
-  end
-  # Fix WSK paths.
-  css = css.gsub('url("../../images', 'url("../images')
-  # Prefix rules.
-  prefixed = AutoprefixerRails.process(css, browsers: AUTOPREFIXER_BROWSERS)
-  # Compress.
-  sass_engine = Sass::Engine.new(prefixed.css, {
-    :style => :compressed,
-    :cache => false,
-    :syntax => :scss,
-  })
-  compressed = sass_engine.render
-  # Output.
-  cssdir = File.dirname(CSS_OUT_WSK)
-  FileUtils.mkdir_p(cssdir) unless File.directory?(cssdir)
-  File.write(CSS_OUT_WSK, compressed)
-end
-
-# The local WSK css file depends on all the WSK inputs.
-CSS_OUT_OCTICONS = "#{LOCAL_STYLES}/octicons.css"
-octicon_css_file = "#{OCTICONS}/octicons.css"
-file CSS_OUT_OCTICONS => octicon_css_file do
-  css = File.read(octicon_css_file)
-  # Fix Octions path.
-  css = css.gsub("url('octicons", "url('../images/octicons")
-  # Prefix rules.
-  prefixed = AutoprefixerRails.process(css, browsers: AUTOPREFIXER_BROWSERS)
-  # Compress.
-  sass_engine = Sass::Engine.new(prefixed.css, {
-    :style => :compressed,
-    :cache => false,
-    :syntax => :scss,
-  })
-  compressed = sass_engine.render
-  # Output.
-  cssdir = File.dirname(CSS_OUT_OCTICONS)
-  FileUtils.mkdir_p(cssdir) unless File.directory?(cssdir)
-  File.write(CSS_OUT_OCTICONS, compressed)
-end
-
-CSS_OUTS = [
-  CSS_OUT_WSK,
-  CSS_OUT_OCTICONS,
-]
-
+css_to_copy = {
+  "#{LOCAL_OCTICONS}/octicons.css" => "#{OCTICONS}/octicons.css",
+}
+css_to_build = {
+  "#{LOCAL_WSK}/styles/wsk.css" => [
+      "#{WSK}/styles/h5bp.css",
+      "#{WSK}/styles/components/components.css",
+      "#{WSK}/styles/main.css",
+    ]
+}
+img_to_copy = {
+  "#{LOCAL_WSK}/images/icons/icons-hinted.ttf" => "#{WSK}/images/icons/icons-hinted.ttf",
+  "#{LOCAL_WSK}/images/icons/icons.eot" => "#{WSK}/images/icons/icons.eot",
+  "#{LOCAL_WSK}/images/icons/icons.svg" => "#{WSK}/images/icons/icons.svg",
+  "#{LOCAL_WSK}/images/icons/icons.ttf" => "#{WSK}/images/icons/icons.ttf",
+  "#{LOCAL_WSK}/images/icons/icons.woff" => "#{WSK}/images/icons/icons.woff",
+  "#{LOCAL_WSK}/images/icons/icons.woff2" => "#{WSK}/images/icons/icons.woff2",
+  "#{LOCAL_OCTICONS}/octicons.eot" => "#{OCTICONS}/octicons.eot",
+  "#{LOCAL_OCTICONS}/octicons.svg" => "#{OCTICONS}/octicons.svg",
+  "#{LOCAL_OCTICONS}/octicons.ttf" => "#{OCTICONS}/octicons.ttf",
+  "#{LOCAL_OCTICONS}/octicons.woff" => "#{OCTICONS}/octicons.woff",
+}
 # Note: WSK font files are not used and instead fonts are linked directly from
 # Google Fonts, but they may be installed locally during development if desired.
+js_to_copy = {
+  "#{LOCAL_SPF}/spf.js" => "#{SPF}/dist/spf.js",
+}
 
-# The local WSK icon files depends on the WSK counterparts.
-IMG_OUTS_WSK = []
-wsk_icon_files = [
-  "#{WSK_IMAGES}/icons/icons-hinted.ttf",
-  "#{WSK_IMAGES}/icons/icons.eot",
-  "#{WSK_IMAGES}/icons/icons.svg",
-  "#{WSK_IMAGES}/icons/icons.ttf",
-  "#{WSK_IMAGES}/icons/icons.woff",
-  "#{WSK_IMAGES}/icons/icons.woff2",
-]
-wsk_icon_files.each do |src|
-  file src => WSK
-  dst = src.sub(WSK_IMAGES, LOCAL_IMAGES)
-  IMG_OUTS_WSK.push(dst)
+all_to_copy = css_to_copy.merge(img_to_copy).merge(js_to_copy)
+css_files = css_to_copy.merge(css_to_build).keys
+img_files = img_to_copy.keys
+js_files = js_to_copy.keys
+
+all_to_copy.each do |dst, src|
   file dst => src do
     dstdir = File.dirname(dst)
     FileUtils.mkdir_p(dstdir) unless File.directory?(dstdir)
@@ -119,32 +84,37 @@ wsk_icon_files.each do |src|
   end
 end
 
-# The local WSK icon files depends on the WSK counterparts.
-IMG_OUTS_OCTICONS = []
-octicons_files = [
-  "#{OCTICONS}/octicons.eot",
-  "#{OCTICONS}/octicons.svg",
-  "#{OCTICONS}/octicons.ttf",
-  "#{OCTICONS}/octicons.woff",
-]
-octicons_files.each do |src|
-  dst = src.sub(OCTICONS, LOCAL_IMAGES)
-  IMG_OUTS_OCTICONS.push(dst)
-  file dst => src do
+css_to_build.each do |dst, srcs|
+  file dst => srcs do
+    css = ""
+    # Concatenate WSK files.
+    srcs.each do |src|
+      css += File.read(src)
+    end
+    # Fix WSK paths.
+    css = css.gsub('url("../../images', 'url("../images')
+    # Prefix rules.
+    prefixed = AutoprefixerRails.process(css, browsers: AUTOPREFIXER_BROWSERS)
+    # Compress.
+    sass_engine = Sass::Engine.new(prefixed.css, {
+      :style => :compressed,
+      :cache => false,
+      :syntax => :scss,
+    })
+    compressed = sass_engine.render
+    # Output.
     dstdir = File.dirname(dst)
     FileUtils.mkdir_p(dstdir) unless File.directory?(dstdir)
-    puts("cp #{src} #{dst}") if verbose
-    FileUtils.cp(src, dst)
+    puts("scss #{srcs} > #{dst}") if verbose
+    File.write(dst, compressed)
   end
 end
-
-IMG_OUTS = IMG_OUTS_WSK + IMG_OUTS_OCTICONS
-
 
 # Tasks.
-task :css => CSS_OUTS
-task :img => IMG_OUTS
-task :assets => [:css, :img]
+task :css => css_files
+task :img => img_files
+task :js => js_files
+task :assets => [:css, :img, :js]
 
 
 task :build => [:assets] do
@@ -162,14 +132,14 @@ end
 
 
 task :stage => [:clean, :assets] do
-  cmd = "bundle exec jekyll build --trace --destination #{STAGING_AREA}"
+  cmd = "bundle exec jekyll build --trace --destination #{STAGING}"
   puts(cmd) if verbose
   system(cmd)
 end
 
 
 task :clean do
-  clean_paths = [SITE, LOCAL_WSK]
+  clean_paths = [SITE, LOCAL]
   puts("rm #{clean_paths}") if verbose
   FileUtils.rm_rf(clean_paths)
 end

--- a/web/_includes/analytics.liquid
+++ b/web/_includes/analytics.liquid
@@ -1,8 +1,10 @@
-<script>
+<script name="analytics">
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+</script>
+<script>
   if (window.location.hostname == 'youtube.github.io') {
     ga('create', '{{ site.analytics.id }}', 'auto');
     ga('send', 'pageview');

--- a/web/_includes/scripts.liquid
+++ b/web/_includes/scripts.liquid
@@ -1,1 +1,2 @@
-<script src="{{ site.baseurl }}/assets/scripts/main.js"></script>
+<script name="spf" src="{{ site.baseurl }}/assets/vendor/spf/2.1.1/spf.js"></script>
+<script name="main" src="{{ site.baseurl }}/assets/scripts/main.js?t={{ site.time | date_to_xmlschema | cgi_escape }}"></script>

--- a/web/_includes/styles.liquid
+++ b/web/_includes/styles.liquid
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/vendor/styles/wsk.css">
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/vendor/styles/octicons.css">
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/styles/main.css">
-<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Roboto:300,600,900|Roboto+Condensed:300,300italic,400,700">
+<link rel="stylesheet" name="roboto" href="http://fonts.googleapis.com/css?family=Roboto:300,600,900|Roboto+Condensed:300,300italic,400,700">
+<link rel="stylesheet" name="wsk" href="{{ site.baseurl }}/assets/vendor/wsk/0.4.0/styles/wsk.css">
+<link rel="stylesheet" name="octicons" href="{{ site.baseurl }}/assets/vendor/octicons/2.1.2/octicons.css">
+<link rel="stylesheet" name="main" href="{{ site.baseurl }}/assets/styles/main.css?t={{ site.time | date_to_xmlschema | cgi_escape }}">

--- a/web/_layouts/base.liquid
+++ b/web/_layouts/base.liquid
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="en" class="spf-link no-js">
 <head>
 {% include meta.liquid %}
 <!-- begin spf head -->
 {% include styles.liquid %}
 <!-- end spf head -->
 </head>
-<body class="{{ page.original_layout }}">
+<body id="body" class="{{ page.original_layout }}">
 
 <header id="app-bar" class="app-bar promote-layer">
   <div class="app-bar-container">
@@ -25,7 +25,11 @@
   </nav>
 </div>
 
+<div id="content">
+<!-- begin spf body: content -->
 {{ content }}
+<!-- end spf body: content -->
+</div>
 
 <footer>
   <div class="container">

--- a/web/_plugins/spfjson.rb
+++ b/web/_plugins/spfjson.rb
@@ -34,21 +34,28 @@ module Jekyll
       html = @output
 
       title_regex = /<title>(.*)<\/title>/m
-      title = title_regex.match(html).captures[0]
       head_regex = /<!-- begin spf head -->(.*)<!-- end spf head -->/m
-      head = head_regex.match(html).captures[0]
+      body_regex = /<!-- begin spf body: (\w+) -->(.*)<!-- end spf body: \1 -->/m
       foot_regex = /<!-- begin spf foot -->(.*)<!-- end spf foot -->/m
-      foot = foot_regex.match(html).captures[0]
-      main_regex = /<main[^>]*>(.*)<\/main>/m
-      main = main_regex.match(html).captures[0]
-      body_class_regex = /<body class="([^"]*)">/
-      body_class = body_class_regex.match(html).captures[0]
+      attr_body_class_regex = /<body[^>]* class="([^"]*)"/
+
+      title = html.match(title_regex)[1]
+      head = html.match(head_regex)[1]
+      body = {}
+      html.scan(body_regex).each do |group|
+        body[group[0]] = group[1]
+      end
+      foot = html.match(foot_regex)[1]
+      attr_body_class = html.match(attr_body_class_regex)[1]
+      attrs = {
+        'body' => {'class' => attr_body_class}
+      }
 
       response = {
         'title' => title,
         'head' => head,
-        'body' => {'main' => main},
-        'attr' => {'body' => {'class' => body_class}},
+        'body' => body,
+        'attr' => attrs,
         'foot' => foot,
       }
       @output = response.to_json

--- a/web/assets/scripts/main.js
+++ b/web/assets/scripts/main.js
@@ -11,7 +11,7 @@
   var nav = document.getElementById('nav');
   var appbar = document.getElementById('app-bar');
   var menu = document.getElementById('menu');
-  var main = document.getElementsByTagName('main')[0];
+  var content = document.getElementById('content');
 
   html.className = html.className.replace('no-js', '');
   if (!('ontouchstart' in window)) {
@@ -47,9 +47,41 @@
     previous = current;
   }
 
-  // Menu
-  main.addEventListener('click', closeMenu);
-  menu.addEventListener('click', toggleMenu);
-  nav.addEventListener('click', handleNavClick);
-  window.addEventListener('scroll', handleScroll);
+  function handleNavigateDone(event) {
+    window.scroll(0,0);
+    handleScroll();
+  }
+
+  function handleScriptUnload(event) {
+    if (event.detail.name == 'main') {
+      dispose();
+    }
+  }
+
+  function init() {
+    content.addEventListener('click', closeMenu);
+    menu.addEventListener('click', toggleMenu);
+    nav.addEventListener('click', handleNavClick);
+    window.addEventListener('scroll', handleScroll);
+
+    spf.init({
+      'cache-unified': true,
+      'url-identifier': '.spf.json'
+    });
+    document.addEventListener('spfdone', handleNavigateDone);
+    document.addEventListener('spfjsbeforeunload', handleScriptUnload);
+  }
+
+  function dispose() {
+    content.removeEventListener('click', closeMenu);
+    menu.removeEventListener('click', toggleMenu);
+    nav.removeEventListener('click', handleNavClick);
+    window.removeEventListener('scroll', handleScroll);
+
+    spf.dispose();
+    document.removeEventListener('spfdone', handleNavigateDone);
+    document.removeEventListener('spfjsbeforeunload', handleScriptUnload);
+  }
+
+  init();
 })();


### PR DESCRIPTION
- Build vendor assets into versioned directories.
- Use timestamped URLs for other JS/CSS.
- Give script/style tags names to avoid unnecessary reloads.
- Update main JS to initialize/dispose SPF.
- Add `spf-link` to the `html` tag to enable all links for SPF.
- Improve parsing when creating SPF JSON files in the Jekyll plugin.

Progress on #224.
