### PR TITLE
Website: Make npm and Bower install instructions easier to find.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,31 +34,22 @@ gaining the performance and user experience benefits of dynamic page loads:
 
 ## Download
 
-The most recent release is **SPF 21 (v2.1.1)**.
-
-> [Download SPF](https://github.com/youtube/spfjs/releases/download/v2.1.1/spfjs-2.1.1-dist.zip)
-
-Link to the minified JS from a CDN:
-
-```html
-<script src="https://ajax.googleapis.com/ajax/libs/spf/2.1.1/spf.js">
-</script>
-```
-
-Or, install with [npm](https://www.npmjs.com/) or [Bower](http://bower.io/):
-
+Install with [npm](https://www.npmjs.com/):
 
 ```sh
-npm install spf@2.1.1
+npm install spf
 ```
+
+Install with [Bower](http://bower.io/):
 
 ```sh
-bower install spf#2.1.1
+bower install spf
 ```
 
-See [the download page](http://youtube.github.io/spfjs/download/) for more
-options.
+Or, see [the download page](http://youtube.github.io/spfjs/download/) for
+options to download the latest release and link to minified JS from a CDN:
 
+> [Download SPF](http://youtube.github.io/spfjs/download/)
 
 
 ## Get Started

--- a/web/_layouts/download.liquid
+++ b/web/_layouts/download.liquid
@@ -6,11 +6,13 @@ layout: base
 
   <header class="page-header container">
     <h2 class="xxlarge text-divider">{{ page.title }}</h2>
-    {% if page.description %}
-      <p class="page-header__excerpt g-wide--push-1 g-wide--pull-1">
+    <p class="page-header__excerpt g-wide--push-1 g-wide--pull-1">
+      {% if page.description %}
         {{ page.description }}
-      </p>
-    {% endif %}
+        <br>
+      {% endif %}
+      <strong>{{ site.release }}</strong>
+    </p>
   </header>
 
   <section class="download-promo">

--- a/web/download.md
+++ b/web/download.md
@@ -4,9 +4,20 @@ description: Get the code.
 layout: download
 ---
 
-The most recent release is **{{ site.release }}**.
 
-You can get the code in several ways:
+## Install with npm or Bower
+
+Install the [npm][npm] package:
+
+```sh
+npm install spf
+```
+
+Install the [Bower][bower] package:
+
+```sh
+bower install spf
+```
 
 
 ## Link to a CDN
@@ -53,22 +64,6 @@ git checkout v{{ site.version }}
 ```
 
 
-## Install with npm
-
-Install the [npm][npm] package:
-
-```sh
-npm install spf@{{ site.version }}
-```
-
-
-## Install with Bower
-
-Install the [Bower][bower] package:
-
-```sh
-bower install spf#{{ site.version }}
-```
 
 
 ## Get Started


### PR DESCRIPTION
- Update the README to remove hard-coding a version and instead link to the
  website download page.  This avoids having version mismatches during
  publishing.
- Update the Downloads page to move npm/Bower instructions to the top.  Put
  latest release version in the page description for better visibility.
