### PR TITLE
Website: "Pretty" format SPF JSON files to reduce diff sizes.

### DIFF
--- a/web/_plugins/spfjson.rb
+++ b/web/_plugins/spfjson.rb
@@ -58,7 +58,9 @@ module Jekyll
         'attr' => attrs,
         'foot' => foot,
       }
-      @output = response.to_json
+      # Use JSON.pretty_generate instead of response.to_json or JSON.generate
+      # to reduce diff sizes during updates, since the files are checked in.
+      @output = JSON.pretty_generate(response)
     end
 
     # Output a .json file.


### PR DESCRIPTION
When updating to website content, it is difficult to see the changes to the
JSON files because the default format places everything on one line.  Use
the "pretty" format to place each key/value on its own line to reduce diff
sizes and make changes more clear.  Since the responses are small, this should
have no measurable impact on site performance.