### PR TITLE
Website: Adjust scroll-to-top behavior to fix target links.

### DIFF
--- a/web/assets/scripts/main.js
+++ b/web/assets/scripts/main.js
@@ -115,11 +115,11 @@
 
   function handleProcess(event) {
     setProgress(animation.PROCESS);
+    window.scroll(0,0);
   }
 
   function handleDone(event) {
     setProgress(animation.DONE);
-    window.scroll(0,0);
     handleScroll();
   }
 


### PR DESCRIPTION
Previously, the `spfdone` event handler was scrolling to the top of the page
after navigation is complete.  However, if a target link is clicked (one with
a hash), then SPF scrolls to the target just before firing the `spfdone`
event.  To fix this, scroll to the top in the `spfprogress` event handler.