### PR TITLE
Ensure resource timing API contains expected data for timing.

### DIFF
--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -317,11 +317,18 @@ spf.nav.request.handleCompleteFromXHR_ = function(url, options, timing,
       // Normalize relative Resource Timing values as
       // Navigation Timing absolute values using navigationStart as base.
       var navigationStart = window.performance.timing.navigationStart;
-      for (var metric in xhr['resourceTiming']) {
-        var value = xhr['resourceTiming'][metric];
-        if (value !== undefined && (spf.string.endsWith(metric, 'Start') ||
-            spf.string.endsWith(metric, 'End') || metric == 'startTime')) {
-          timing[metric] = navigationStart + Math.round(value);
+
+      // Use resource timing data (RT) only if RT.startTime is later than
+      // the one provided by SPF when request was initiated.
+      // This is specifically affecting Chrome 40+. See http://crbug.com/375388
+      var startTime = navigationStart + xhr['resourceTiming']['startTime'];
+      if (startTime >= timing['startTime']) {
+        for (var metric in xhr['resourceTiming']) {
+          var value = xhr['resourceTiming'][metric];
+          if (value !== undefined && (spf.string.endsWith(metric, 'Start') ||
+              spf.string.endsWith(metric, 'End') || metric == 'startTime')) {
+            timing[metric] = navigationStart + Math.round(value);
+          }
         }
       }
     }

--- a/src/client/net/xhr.js
+++ b/src/client/net/xhr.js
@@ -140,7 +140,9 @@ spf.net.xhr.send = function(method, url, data, opt_options) {
       // Record Resource Timing relative timings (where available) to later be
       // converted into Navigation Timing absolute timings.
       if (window.performance && window.performance.getEntriesByName) {
-        xhr['resourceTiming'] = window.performance.getEntriesByName(url)[0];
+        // Get always the latest entry available just in case old entries were
+        // not cleared out by performance.clearResourceTimings.
+        xhr['resourceTiming'] = window.performance.getEntriesByName(url).pop();
       }
       // If processing chunks as they arrive and the state was transitioned
       // at response end to DONE without a LOADING, process the final chunk now.


### PR DESCRIPTION
This PR covers:
1. Use timing data for the latest entry of a given URL, just in case there are multiple entries, the last one should prevail;
2. Use Resource Timing data only if its startTime is greater than the one provided by SPF when request was initiated.