### PR TITLE
Update contributing guidelines with a 64 character line length.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,20 @@
 # Contributing
 
 SPF is an open source project. It is licensed using the
-[MIT License][]. We appreciate pull requests; here are our guidelines:
+[MIT License][]. We appreciate pull requests; here are our
+guidelines:
 
-1.  [File a bug][] (if there isn't one already).  If your patch is going to be
-    large it might be a good idea to get the discussion started early.  We are
-    happy to discuss it in a new issue beforehand, and you can always email
-    spfjs@googlegroups.com about future work.
-2.  Due to legal reasons, all contributors must sign a contributor license
-    agreement, either for an [individual][] or [corporation][], before a
-    patch can be accepted.
+1.  [File a bug][] (if there isn't one already).  If your patch
+    is going to be large it might be a good idea to get the
+    discussion started early.  We are happy to discuss it in a
+    new issue beforehand, and you can always email
+    <spfjs@googlegroups.com> about future work.
+2.  Due to legal reasons, all contributors must sign a
+    contributor license agreement, either for an [individual][]
+    or [corporation][], before a patch can be accepted.
 3.  Please use [Google JavaScript Style][].
-4.  We ask that you squash all the commits together before pushing and that
-    your commit message references the bug.
+4.  We ask that you squash all the commits together before
+    pushing and that your commit message references the bug.
 
 [MIT License]: http://opensource.org/licenses/MIT
 [File a bug]: https://github.com/youtube/spfjs/issues


### PR DESCRIPTION
Also ensure that the group email address is linked used standard Markdown syntax.