### PR TITLE
Prevent early scrolling during history navigation (experimental).

### DIFF
--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -345,6 +345,22 @@ spf.nav.handleHistory_ = function(url, opt_state) {
   if (!spf.nav.dispatchHistory_(url, info.referer, info.current)) {
     return;
   }
+  // If navigating for this history change and a scroll position is set, ensure
+  // the browser doesn't scroll too early.  The browser default behavior is to
+  // scroll to the position when pushState was called just after a popState
+  // event is fired.  This is okay only if using history to move around a single
+  // page or if all content can be rendered synchronously during the popState
+  // event handling.  Since navigation content updates have at least one
+  // asynchronous break, avoid this early scroll by immediately scrolling back
+  // to the current position after the event.  The proper position will be set
+  // once content is updated.
+  if (info.position && spf.config.get('experimental-scroll-position')) {
+    var position = [window.pageXOffset, window.pageYOffset];
+    setTimeout(function() {
+      spf.debug.debug('    resetting early scroll to ', position);
+      window.scroll.apply(null, position);
+    }, 0);
+  }
   // Navigate to the URL.
   // NOTE: The persistent parameters are not appended here because they should
   // already be set on the URL if necessary.


### PR DESCRIPTION
When handling a history change event, save the current position and scroll to
that (current) position immediately after handling the event to prevent the
browser from incorrectly scrolling too early.

The browser default behavior is to scroll to the position when `pushState` was
called just after firing a `popState` event.  This is okay only if using
`pushState` to move around a single page or if all content can be rendered
synchronously during the `popState` event handling.  Since navigation content
updates are asynchronous (either from cache or from network), avoid this early
scroll by immediately scrolling back to the current position after the event.
The proper position is then (re)set once the content is updated.

For now, guard this behavior behind the `experimental-scroll-position` config.

Progress on #285.