### PR TITLE
Ensure the proper compilation flags are set for the bootloader.

### DIFF
--- a/bin/configure.js
+++ b/bin/configure.js
@@ -197,6 +197,7 @@ function variables(ninja) {
     '--output_wrapper_file $wrapper_js'
   ];
   var bootloader = [
+    '--define "SPF_BOOTLOADER=true"',
     '--closure_entry_point spf.bootloader',
     '--output_wrapper "(function(){%output%})();"'
   ];


### PR DESCRIPTION
This returns the bootloader to its previous size:
- normal: from 4508 bytes to 3164 bytes
- gzip: from 2060 bytes to 1584 bytes