### PR TITLE
Release "scroll to top during navigation".

### DIFF
--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -56,10 +56,8 @@ spf.nav.init = function() {
                   spf.nav.handleMouseDown_);
   }
   // Handle scrolls for preventing early scrolling during history changes.
-  if (spf.config.get('experimental-scroll-position')) {
-    document.addEventListener('scroll', spf.nav.handleScroll_, false);
-    spf.state.set(spf.state.Key.NAV_SCROLL_LISTENER, spf.nav.handleScroll_);
-  }
+  document.addEventListener('scroll', spf.nav.handleScroll_, false);
+  spf.state.set(spf.state.Key.NAV_SCROLL_LISTENER, spf.nav.handleScroll_);
 };
 
 
@@ -391,7 +389,7 @@ spf.nav.handleHistory_ = function(url, opt_state) {
   // asynchronous break, avoid this by saving the current page position and
   // scrolling immediately back to it when the browser scrolls early.
   // The proper position will be set once content is updated.
-  if (info.position && spf.config.get('experimental-scroll-position')) {
+  if (info.position) {
     spf.nav.setScrollTempPosition_();
   }
   // Navigate to the URL.
@@ -624,7 +622,7 @@ spf.nav.navigateScroll_ = function(url, info) {
       el.scrollIntoView();
       info.scrolled = true;
     }
-  } else if (!info.scrolled && spf.config.get('experimental-scroll-position')) {
+  } else if (!info.scrolled) {
     spf.debug.debug('    clearing scroll temp position');
     spf.nav.clearScrollTempPosition_();
     spf.debug.debug('    scrolling to top');

--- a/src/client/nav/response.js
+++ b/src/client/nav/response.js
@@ -225,8 +225,7 @@ spf.nav.response.process = function(url, response, opt_info, opt_callback) {
         // Other history navigation requests handle scrolling after all
         // processing is done to avoid jumping to the top and back down to the
         // saved position afterwards.
-        if (isNavigate && !hasPosition && !hasScrolled &&
-            spf.config.get('experimental-scroll-position')) {
+        if (isNavigate && !hasPosition && !hasScrolled) {
           spf.state.set(spf.state.Key.NAV_SCROLL_TEMP_POSITION, null);
           spf.state.set(spf.state.Key.NAV_SCROLL_TEMP_URL, null);
           spf.debug.debug('    scrolling to top');


### PR DESCRIPTION
Promote previous `experimental-scroll-position` logic to be always enabled.

This enables scrolling to top when processing the first HTML fragment of a
new response.  If navigating to previous entry and a position is stored in
history, the saved position will be scrolled to after processing is complete.

Closes #285.