### PR TITLE
Release "extract resources before caching responses".

### DIFF
--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -384,10 +384,7 @@ spf.nav.request.handleCompleteFromXHR_ = function(url, options, timing,
       }
       return;
     }
-    parts = spf.array.toArray(xhr.response);
-    if (spf.config.get('experimental-parse-extract')) {
-      parts = spf.nav.response.extract(parts);
-    }
+    parts = spf.nav.response.extract(spf.array.toArray(xhr.response));
   } else {
     // Otherwise, parsing may need to be done.  Always attempt a full parse with
     // error handling. A multipart response parsed on-the-fly via chunking may

--- a/src/client/nav/response.js
+++ b/src/client/nav/response.js
@@ -88,20 +88,14 @@ spf.nav.response.parse = function(text, opt_multipart, opt_lastDitch) {
         extra = extra.substring(0, extra.length - lastDitchHalfToken.length);
       }
     }
-    if (spf.config.get('experimental-parse-extract')) {
-      parts = spf.nav.response.extract(parts);
-    }
+    parts = spf.nav.response.extract(parts);
     return {
       parts: /** @type {Array.<spf.SingleResponse>} */(parts),
       extra: extra
     };
   } else {
     var response = JSON.parse(text);
-
-    var parts = spf.array.toArray(response);
-    if (spf.config.get('experimental-parse-extract')) {
-      parts = spf.nav.response.extract(parts);
-    }
+    var parts = spf.nav.response.extract(spf.array.toArray(response));
     return {
       parts: /** @type {Array.<spf.SingleResponse>} */(parts),
       extra: ''
@@ -506,16 +500,18 @@ spf.nav.response.extract = function(response) {
   spf.debug.debug('spf.nav.response.extract', response);
   var parts = spf.array.toArray(response);
   spf.array.each(parts, function(part) {
-    if (part['head']) {
-      part['head'] = spf.nav.response.extract_(part['head']);
-    }
-    if (part['body']) {
-      for (var id in part['body']) {
-        part['body'][id] = spf.nav.response.extract_(part['body'][id]);
+    if (part) {
+      if (part['head']) {
+        part['head'] = spf.nav.response.extract_(part['head']);
       }
-    }
-    if (part['foot']) {
-      part['foot'] = spf.nav.response.extract_(part['foot']);
+      if (part['body']) {
+        for (var id in part['body']) {
+          part['body'][id] = spf.nav.response.extract_(part['body'][id]);
+        }
+      }
+      if (part['foot']) {
+        part['foot'] = spf.nav.response.extract_(part['foot']);
+      }
     }
   });
   return response;


### PR DESCRIPTION
Promote previous `experimental-parse-extract` logic to be always enabled.

This eliminates work for cached or prefetched responses by extracting resources
from HTML strings during parsing, which happens once before the response is
cached, instead of during processing, which happens each time the response is
used for navigation.

Closes #307.