### PR TITLE
Ensure that requests for preconnect target links are always sent.

### DIFF
--- a/src/client/net/connect.js
+++ b/src/client/net/connect.js
@@ -4,7 +4,8 @@
 // See the LICENSE file for details.
 
 /**
- * @fileoverview Functions for handling connections (i.e. pre-resolving DNS).
+ * @fileoverview Functions for handling connections (i.e. pre-resolving DNS
+ * and establishing the TCP AND TLS handshake).
  *
  * @author nicksay@google.com (Alex Nicksay)
  */
@@ -18,8 +19,7 @@ goog.require('spf.tracing');
 
 /**
  * Preconnects to a URL.
- * Use to both resolve DNS and establish a socket connections before requests
- * are made.
+ * Use to both resolve DNS and establish connections before requests are made.
  *
  * @param {string|Array.<string>} urls One or more URLs to preconnect.
  */
@@ -29,7 +29,11 @@ spf.net.connect.preconnect = function(urls) {
   // Convert to an array if needed.
   urls = spf.array.toArray(urls);
   spf.array.each(urls, function(url) {
-    spf.net.resource.prefetch(type, url);
+    // When preconnecting, always fetch the image and make the request.
+    // This is necessary to consistenly establish connections to repeat
+    // URLs when the keep-alive time is shorter than the interval between
+    // attempts.
+    spf.net.resource.prefetch(type, url, true);  // Force repeat fetching.
   });
 };
 

--- a/src/client/net/connect_test.js
+++ b/src/client/net/connect_test.js
@@ -1,0 +1,46 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Use of this source code is governed by The MIT License.
+// See the LICENSE file for details.
+
+/**
+ * @fileoverview Tests for handling connections.
+ */
+
+goog.require('spf.array');
+goog.require('spf.net.connect');
+goog.require('spf.net.resource');
+
+
+describe('spf.net.connect', function() {
+
+  var IMG = spf.net.resource.Type.IMG;
+
+  beforeEach(function() {
+    spyOn(spf.net.resource, 'prefetch');
+  });
+
+
+  describe('preconnect', function() {
+
+    it('calls for a single url', function() {
+      var url = 'url/a';
+      var force = true;
+      spf.net.connect.preconnect(url);
+      expect(spf.net.resource.prefetch).toHaveBeenCalledWith(IMG, url, force);
+    });
+
+    it('calls for multiples urls', function() {
+      var urls = ['url/b-1', 'url/b-2'];
+      var force = true;
+      spf.net.connect.preconnect(urls);
+      spf.array.each(urls, function(url) {
+        expect(spf.net.resource.prefetch).toHaveBeenCalledWith(
+            IMG, url, force);
+      });
+    });
+
+  });
+
+
+});


### PR DESCRIPTION
Before, preconnect links specified by `<link rel="spf-preconnect">` tags would
be treated like other prefetch resources in that they were only done once.  This
works for static resources, which generally have long cache lifetimes and do not
need to be prefetched multiple times.  However, when preconnecting URLs, the
server's HTTP keep-alive time can close an opened connection before the next
use (or preconnect attempt) occurs.  To ensure that connections are correctly
established, always send requests for preconnect target links.

Progress on #124.