### PR TITLE
Web: Use MD5 hashcodes to version JS/CSS assets

### DIFF
--- a/web/includes/scripts.liquid
+++ b/web/includes/scripts.liquid
@@ -1,2 +1,2 @@
 <script name="spf" src="{{ site.baseurl }}/assets/vendor/spf/2.1.1/spf.js"></script>
-<script name="main" src="{{ site.baseurl }}/assets/scripts/main.js?t={{ site.time | date_to_xmlschema | cgi_escape }}"></script>
+<script name="main" src="{{ site.baseurl }}{{ '/assets/scripts/main.js' | md5_cgi_url }}"></script>

--- a/web/includes/styles.liquid
+++ b/web/includes/styles.liquid
@@ -1,4 +1,4 @@
 <link rel="stylesheet" name="roboto" href="//fonts.googleapis.com/css?family=Roboto:300,600,900|Roboto+Condensed:300,300italic,400,700|Inconsolata:400">
 <link rel="stylesheet" name="wsk" href="{{ site.baseurl }}/assets/vendor/wsk/0.4.0/styles/wsk.css">
 <link rel="stylesheet" name="octicons" href="{{ site.baseurl }}/assets/vendor/octicons/2.1.2/octicons.css">
-<link rel="stylesheet" name="main" href="{{ site.baseurl }}/assets/styles/main.css?t={{ site.time | date_to_xmlschema | cgi_escape }}">
+<link rel="stylesheet" name="main" href="{{ site.baseurl }}{{ '/assets/styles/main.css' | md5_cgi_url }}">

--- a/web/plugins/staticmd5.rb
+++ b/web/plugins/staticmd5.rb
@@ -1,0 +1,64 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Use of this source code is governed by The MIT License.
+# See the LICENSE file for details.
+
+# Jekyll plugin to generate a MD5 hashcode for every static file.
+#
+# Author:: nicksay@google.com (Alex Nicksay)
+
+
+require 'digest'
+
+
+module Jekyll
+
+  class StaticFile
+
+    def md5
+      Digest::MD5.file(path).hexdigest
+    end
+
+    def to_liquid
+      {
+        "path"          => File.join("", relative_path),
+        "modified_time" => mtime.to_s,
+        "extname"       => File.extname(relative_path),
+        "md5"           => md5
+      }
+    end
+
+  end
+
+
+  class StaticMD5Generator < Generator
+
+    safe true
+    priority :low
+
+    def generate(site)
+      static_files_index = {}
+      site.static_files.each do |static_file|
+        path = File.join("", static_file.relative_path)
+        static_files_index[path] = static_file
+      end
+      site.data['static_files_index'] = static_files_index
+    end
+
+  end
+
+
+  module StaticMD5Filter
+
+    def md5_cgi_url(input)
+      static_file = @context.registers[:site].data['static_files_index'][input]
+      "#{input}?md5=#{static_file.md5}"
+    end
+
+  end
+
+
+end
+
+
+Liquid::Template.register_filter(Jekyll::StaticMD5Filter)


### PR DESCRIPTION
This change reduces needless version churn.  Before, the main JS/CSS files
were assigned new versions for each build based on the build timestamp.
After, the files will only be assigned new versions when they change based
on the MD5 hashcode of their contents.