### PR TITLE
Synchronously handle only background cached responses (experimental)

### DIFF
--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -114,6 +114,9 @@ spf.nav.request.send = function(url, opt_options) {
     // the cache response synchronously.
     if (spf.config.get('experimental-sync-response-cache')) {
       handleCache();
+    } else if (spf.config.get('experimental-sync-response-cache-background') &&
+               document.hidden) {
+      handleCache();
     } else {
       setTimeout(handleCache, 0);
     }


### PR DESCRIPTION
To avoid the forced 1s delay in WebKit browsers when handling cached responses
when in the background, synchronously execute the handler function instead of
using a `setTimeout` of 0, but only if `document.webkitVisibilityState` is
`'hidden'`.  For evaluation and testing, guard this behavior behind a
`experimental-sync-response-cache-background` config flag.

Progress on #337