### PR TITLE
Release "handle cached responses via deferred execution"

### DIFF
--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -110,18 +110,10 @@ spf.nav.request.send = function(url, opt_options) {
     // cache response is returned asynchronously.
     var handleCache = spf.bind(spf.nav.request.handleResponseFromCache_, null,
                                url, options, timing, cached.key, response);
-    // However, when WebKit browsers are in a background tab, setTimeout calls
-    // are deprioritized to execute with a 1s delay.  Experimentally avoid this.
-    if (spf.config.get('experimental-defer-response-cache')) {
-      spf.async.defer(handleCache);
-    } else if (spf.config.get('experimental-sync-response-cache')) {
-      handleCache();
-    } else if (spf.config.get('experimental-sync-response-cache-background') &&
-               document.hidden) {
-      handleCache();
-    } else {
-      setTimeout(handleCache, 0);
-    }
+    // When WebKit browsers are in a background tab, setTimeout calls are
+    // deprioritized to execute with a 1s delay.  Avoid this by using
+    // postMessage to schedule execution; see spf.async.delay for details.
+    spf.async.defer(handleCache);
     // Return null because no XHR is made.
     return null;
   } else {

--- a/src/client/nav/request_test.js
+++ b/src/client/nav/request_test.js
@@ -8,6 +8,7 @@
  */
 
 goog.require('spf');
+goog.require('spf.async');
 goog.require('spf.cache');
 goog.require('spf.nav.request');
 goog.require('spf.net.xhr');
@@ -16,6 +17,10 @@ goog.require('spf.url');
 
 
 describe('spf.nav.request', function() {
+
+  // Jasmine supports a mock clock for setTimeout, but postMessage support isn't
+  // easily handled.  Instead, disable use of postMessage for tests.
+  spf.async.POSTMESSAGE_SUPPORTED_ = false;
 
   var MOCK_DELAY = 10;
   var EXPECTED_TIMING = {'spfCached': false, 'spfPrefetched': false};


### PR DESCRIPTION
Promote previous `experimental-defer-response-cache` logic to always be enabled.
Remove alternate and conflicting `experimental-sync-response-cache` and
`experimental-sync-response-cache-background` logic.

This avoids the forced 1s delay in WebKit browsers when handling cached
responses in the background by deferring execution of the handler
function using the `spf.async` package, which attempts to use `postMessage`
instead of `setTimeout` for browsers that support it.

Closes #337