### PR TITLE
Migrate Travis CI from legacy to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ before_script:
   - npm run lint
 script:
   - npm test
+sudo: false


### PR DESCRIPTION
Enable the new Travis CI container-based infrastructure for faster builds.
This is done by adding `sudo: false` to the `.travis.yml` file.