### PR TITLE
Prevent spurious output warnings in the PhantomJS runner for Jasmine 2.3

### DIFF
--- a/third-party/phantomjs/examples/run-jasmine2.js
+++ b/third-party/phantomjs/examples/run-jasmine2.js
@@ -35,6 +35,17 @@ function waitFor(testFx, onReady, timeOutMillis) {
         }, 100); //< repeat check every 100ms
 };
 
+/**
+ * Exits without triggering "Unsafe javascript attempt" output.  See
+ * {@link https://github.com/ariya/phantomjs/issues/12697}
+ *
+ * @param page the Page object
+ * @param code the exit code
+ */
+function exit(code) {
+    setTimeout(function(){ phantom.exit(code); }, 0);
+    phantom.onError = function(){};
+}
 
 if (system.args.length !== 2) {
     console.log('Usage: run-jasmine2.js URL');
@@ -87,7 +98,7 @@ page.open(system.args[1], function(status){
                   return 0;
                 }
             });
-            phantom.exit(exitCode);
+            exit(exitCode);
         });
     }
 });


### PR DESCRIPTION
As described in ariya/phantomjs#12697, PhantomJS runs can output spurious
warnings to the console starting with `Unsafe Javascript attempt`.  Using
a `setTimeout` to call `phantom.exit` immediately after removing the global
`onError` handler eliminates these messages.

Progress on #364