### PR TITLE
Improve type specificity for JS Compiler.

### DIFF
--- a/src/client/dom/dom.js
+++ b/src/client/dom/dom.js
@@ -15,19 +15,19 @@ goog.require('spf');
 
 
 /**
- * Gets document nodes matching a selector.
+ * Gets nodes matching a selector.
  *
  * Note: IE8 does not support CSS3 selectors, and unsupported browsers will
  * return an empty Array.
  *
  * @param {string} selector Selector to match.
- * @param {Document=} opt_document Optional document to query.
+ * @param {(Document|Element)=} opt_root Optional document or element to query.
  * @return {Array.<Node>|NodeList} nodes Matching nodes.
  */
-spf.dom.query = function(selector, opt_document) {
-  var doc = opt_document || document;
-  if (doc.querySelectorAll) {
-    return doc.querySelectorAll(selector);
+spf.dom.query = function(selector, opt_root) {
+  var root = opt_root || document;
+  if (root.querySelectorAll) {
+    return root.querySelectorAll(selector);
   }
   return [];
 };

--- a/src/client/net/resource.js
+++ b/src/client/net/resource.js
@@ -300,8 +300,8 @@ spf.net.resource.create = function(type, url, opt_callback, opt_document,
     // reload it in-place to prevent changing the order of the cascade.
     // It is only reloaded it in-place if it already exists in the head,
     // otherwise the new element is appended.
-    var prevEl = opt_prevUrl && spf.net.resource.find(type, opt_prevUrl,
-        targetEl);
+    var prevEl = opt_prevUrl ?
+        spf.net.resource.find(type, opt_prevUrl, targetEl) : null;
     if (prevEl) {
       targetEl.insertBefore(el, prevEl);
     } else {
@@ -331,19 +331,20 @@ spf.net.resource.destroy = function(type, url, opt_document) {
 
 
 /**
- * Finds a previously created element that was appended to the document.
+ * Finds a previously created element.
  * See {@link #create}.
  *
  * @param {spf.net.resource.Type} type Type of the resource.
  * @param {string} url URL of the resource.
- * @param {Document=} opt_document Optional document to use.
+ * @param {(Document|Element)=} opt_root Optional document or element to
+ *     search in.
  * @return {!Node|undefined} The found element, or undefined if not found.
  */
-spf.net.resource.find = function(type, url, opt_document) {
+spf.net.resource.find = function(type, url, opt_root) {
   var label = spf.net.resource.label(url);
   var cls = spf.net.resource.key(type, label);
   var selector = '.' + cls;
-  var els = spf.dom.query(selector, opt_document);
+  var els = spf.dom.query(selector, opt_root);
   return els[0];
 };
 


### PR DESCRIPTION
The type signatures for the following functions have been updated:
  `spf.dom.query`
  `spf.net.resource.find`