### PR TITLE
Fix setting "value" attributes.

### DIFF
--- a/src/client/dom/dom.js
+++ b/src/client/dom/dom.js
@@ -155,6 +155,13 @@ spf.dom.setAttributes = function(element, attributes) {
       element.style.cssText = value;
     } else {
       element.setAttribute(name, value);
+      // Updating the "value" attribute of an input via `el.setAttribute` does
+      // not change what is displayed, and assigning directly via `el.value` is
+      // needed.  But, _only_ updating via `el.value` means that calls to
+      // `el.getAttribute` will return the original value.  So, do both.
+      if (name == 'value') {
+        element[name] = value;
+      }
     }
   }
 };

--- a/src/client/dom/dom_test.js
+++ b/src/client/dom/dom_test.js
@@ -1,0 +1,46 @@
+// Copyright 2016 Google Inc. All rights reserved.
+//
+// Use of this source code is governed by The MIT License.
+// See the LICENSE file for details.
+
+/**
+ * @fileoverview Tests for basic DOM manipulation functions.
+ */
+
+goog.require('spf.dom');
+goog.require('spf.string');
+
+
+describe('spf.dom', function() {
+
+
+  describe('setAttributes', function() {
+
+    it('sets "class" correctly', function() {
+      var el = document.createElement('div');
+      spf.dom.setAttributes(el, {'class': 'foo'});
+      expect(el.className).toEqual('foo');
+      expect(el.getAttribute('class')).toEqual('foo');
+    });
+
+    it('sets "style" correctly', function() {
+      var el = document.createElement('span');
+      spf.dom.setAttributes(el, {'style': 'display: block;'});
+      // Note that some browsers add trailing whitespace to the
+      // style text here, so trim it for the test.
+      expect(spf.string.trim(el.style.cssText)).toEqual('display: block;');
+      expect(spf.string.trim(el.getAttribute('style')))
+          .toEqual('display: block;');
+    });
+
+    it('sets "value" correctly', function() {
+      var el = document.createElement('input');
+      spf.dom.setAttributes(el, {'value': 'bar'});
+      expect(el.value).toEqual('bar');
+      expect(el.getAttribute('value')).toEqual('bar');
+    });
+
+  });
+
+
+});


### PR DESCRIPTION
When setting an `input` element's `value` attribute via `el.setAttribute()`,
the displayed value is not updated, and the original value returned by
`el.value` instead of the new value.  To fix this, assign the `value` attribute
both ways.

Also, add tests to catch this problem.

Closes #359.