### PR TITLE
Fix reloads when the URL contains a hash

### DIFF
--- a/src/client/nav/nav_test.js
+++ b/src/client/nav/nav_test.js
@@ -476,13 +476,13 @@ describe('spf.nav', function() {
     });
 
 
-    it('denies hash to standard for same page', function() {
+    it('allows hash to standard for same page', function() {
       var current = window.location.href;
       var currentWithTargetHash = spf.url.absolute(current) + '#target';
       var currentWithEmptyHash = spf.url.absolute(current) + '#';
       var url = current;
-      expect(spf.nav.isNavigable_(url, currentWithTargetHash)).toBe(false);
-      expect(spf.nav.isNavigable_(url, currentWithEmptyHash)).toBe(false);
+      expect(spf.nav.isNavigable_(url, currentWithTargetHash)).toBe(true);
+      expect(spf.nav.isNavigable_(url, currentWithEmptyHash)).toBe(true);
     });
 
 


### PR DESCRIPTION
The previous change explicitly called `window.location.reload()` after assigning
to `window.location.href` to ensure a reload happens for URLs that contain a
hash.  However, an immediate call to `window.location.reload()` will cancel
navigation started by the assignment to `window.location.href` for other cases.
Fix this by limiting calls to `window.location.reload()` for only those cases
where it is needed.

Fixes #377