### PR TITLE
Correct copyright years in file license headers.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2012-2015 Google, Inc.
+Copyright (c) 2012-2016 Google, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ updates.
 ## License
 
 MIT  
-Copyright 2012-2014 Google, Inc.
+Copyright 2012-2016 Google, Inc.
 
 
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/base_test.js
+++ b/src/client/base_test.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/cache/cache.js
+++ b/src/client/cache/cache.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/cache/cache_test.js
+++ b/src/client/cache/cache_test.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/debug/debug.js
+++ b/src/client/debug/debug.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/dom/classlist.js
+++ b/src/client/dom/classlist.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/dom/dataset.js
+++ b/src/client/dom/dataset.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/dom/dom.js
+++ b/src/client/dom/dom.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/history/history.js
+++ b/src/client/history/history.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/history/history_test.js
+++ b/src/client/history/history_test.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/nav/nav_test.js
+++ b/src/client/nav/nav_test.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/nav/request_test.js
+++ b/src/client/nav/request_test.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/nav/response.js
+++ b/src/client/nav/response.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/nav/response_test.js
+++ b/src/client/nav/response_test.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/net/xhr.js
+++ b/src/client/net/xhr.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/pubsub/pubsub.js
+++ b/src/client/pubsub/pubsub.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/pubsub/pubsub_test.js
+++ b/src/client/pubsub/pubsub_test.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/string/string.js
+++ b/src/client/string/string.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/string/string_test.js
+++ b/src/client/string/string_test.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/tasks/tasks.js
+++ b/src/client/tasks/tasks.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/url/url.js
+++ b/src/client/url/url.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/client/url/url_test.js
+++ b/src/client/url/url_test.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/server/demo/app.py
+++ b/src/server/demo/app.py
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2012 Google Inc. All rights reserved.
 #
 # Use of this source code is governed by The MIT License.
 # See the LICENSE file for details.

--- a/src/server/demo/static/app-chunked.js
+++ b/src/server/demo/static/app-chunked.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/server/demo/static/app-demo.css
+++ b/src/server/demo/static/app-demo.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2013 Google Inc. All rights reserved.
 
 Use of this source code is governed by The MIT License.
 See the LICENSE file for details.

--- a/src/server/demo/static/app-demo.js
+++ b/src/server/demo/static/app-demo.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2013 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/server/demo/static/app.css
+++ b/src/server/demo/static/app.css
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2012 Google Inc. All rights reserved.
 
 Use of this source code is governed by The MIT License.
 See the LICENSE file for details.

--- a/src/server/demo/static/app.js
+++ b/src/server/demo/static/app.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Google Inc. All rights reserved.
+// Copyright 2012 Google Inc. All rights reserved.
 //
 // Use of this source code is governed by The MIT License.
 // See the LICENSE file for details.

--- a/src/server/demo/templates/base.tmpl
+++ b/src/server/demo/templates/base.tmpl
@@ -1,7 +1,7 @@
 $def with (content)
 <!doctype HTML>
 <!--
-Copyright 2014 Google Inc. All rights reserved.
+Copyright 2012 Google Inc. All rights reserved.
 
 Use of this source code is governed by The MIT License.
 See the LICENSE file for details.

--- a/src/server/demo/templates/chunked.tmpl
+++ b/src/server/demo/templates/chunked.tmpl
@@ -1,4 +1,4 @@
-$# Copyright 2014 Google Inc. All rights reserved.
+$# Copyright 2013 Google Inc. All rights reserved.
 $#
 $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.

--- a/src/server/demo/templates/demo.tmpl
+++ b/src/server/demo/templates/demo.tmpl
@@ -1,6 +1,6 @@
 $def with (page_num)
 
-$# Copyright 2014 Google Inc. All rights reserved.
+$# Copyright 2012 Google Inc. All rights reserved.
 $#
 $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.

--- a/src/server/demo/templates/index.tmpl
+++ b/src/server/demo/templates/index.tmpl
@@ -1,4 +1,4 @@
-$# Copyright 2014 Google Inc. All rights reserved.
+$# Copyright 2012 Google Inc. All rights reserved.
 $#
 $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.

--- a/src/server/demo/templates/index_ajax.tmpl
+++ b/src/server/demo/templates/index_ajax.tmpl
@@ -1,4 +1,4 @@
-$# Copyright 2014 Google Inc. All rights reserved.
+$# Copyright 2012 Google Inc. All rights reserved.
 $#
 $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.

--- a/src/server/demo/templates/missing.tmpl
+++ b/src/server/demo/templates/missing.tmpl
@@ -1,4 +1,4 @@
-$# Copyright 2014 Google Inc. All rights reserved.
+$# Copyright 2013 Google Inc. All rights reserved.
 $#
 $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.

--- a/src/server/demo/templates/other.tmpl
+++ b/src/server/demo/templates/other.tmpl
@@ -1,6 +1,6 @@
 $def with (referer)
 
-$# Copyright 2014 Google Inc. All rights reserved.
+$# Copyright 2013 Google Inc. All rights reserved.
 $#
 $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.

--- a/src/server/demo/templates/spec.tmpl
+++ b/src/server/demo/templates/spec.tmpl
@@ -1,4 +1,4 @@
-$# Copyright 2014 Google Inc. All rights reserved.
+$# Copyright 2012 Google Inc. All rights reserved.
 $#
 $# Use of this source code is governed by The MIT License.
 $# See the LICENSE file for details.

--- a/web/plugins/mdlinks.rb
+++ b/web/plugins/mdlinks.rb
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2015 Google Inc. All rights reserved.
 #
 # Use of this source code is governed by The MIT License.
 # See the LICENSE file for details.


### PR DESCRIPTION
The license header copyright year should be the year in which the file was
created. This should not be changed if you edit, move, or copy the file.