### PR TITLE
Allow custom headers to be sent with requests

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -235,6 +235,13 @@ spf.RequestOptions;
 
 
 /**
+ * Optional map of headers to send with the request.
+ * @type {Object.<string>|undefined}
+ */
+spf.RequestOptions.prototype.experimental_headers;
+
+
+/**
  * Optional method with which to send the request; defaults to "GET".
  * @type {string|undefined}
  */

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -273,6 +273,7 @@ spf.MultipartResponse;
 
 /**
  * Type definition for the configuration options for requesting a URL.
+ * - experimental_headers: optional map of headers to send with the request.
  * - method: optional method with which to send the request; defaults to "GET".
  * - onDone: optional callback when either repsonse is done being processed.
  * - onError: optional callback if an error occurs.
@@ -286,6 +287,7 @@ spf.MultipartResponse;
  *       is set to "POST".
  *
  * @typedef {{
+ *   experimental_headers: (Object.<string>|undefined),
  *   method: (string|undefined),
  *   onDone: (function(spf.EventDetail)|undefined),
  *   onError: (function(spf.EventDetail)|undefined),

--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -571,6 +571,7 @@ spf.nav.navigateSendRequest_ = function(url, options, info) {
 
   var xhr = spf.nav.request.send(url, {
     method: options['method'],
+    headers: options['experimental_headers'],
     onPart: handlePart,
     onError: handleError,
     onSuccess: handleSuccess,
@@ -976,6 +977,7 @@ spf.nav.load_ = function(url, options, info) {
 
   spf.nav.request.send(url, {
     method: options['method'],
+    headers: options['experimental_headers'],
     onPart: handlePart,
     onError: handleError,
     onSuccess: handleSuccess,
@@ -1033,6 +1035,7 @@ spf.nav.prefetch_ = function(url, options, info) {
 
   var xhr = spf.nav.request.send(url, {
     method: options['method'],
+    headers: options['experimental_headers'],
     onPart: handlePart,
     onError: handleError,
     onSuccess: handleSuccess,

--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -27,6 +27,7 @@ goog.require('spf.url');
 /**
  * Type definition for the configuration options for an SPF request.
  * - method: optional method with which to send the request; defaults to "GET".
+ * - headers: optional map of headers to send with the request.
  * - onPart: optional callback to execute with the parts of a multipart
  *       response.  The first argumet is the requested URL; the second argument
  *       is the partial response object.  If valid
@@ -53,6 +54,7 @@ goog.require('spf.url');
  *
  * @typedef {{
  *   method: (string|undefined),
+ *   headers: (Object.<string>|undefined),
  *   onPart: (function(string, spf.SingleResponse)|undefined),
  *   onError: (function(string, (Error|boolean))|undefined),
  *   onSuccess: (function(string,
@@ -119,6 +121,20 @@ spf.nav.request.send = function(url, opt_options) {
   } else {
     spf.debug.debug('    sending XHR');
     var headers = {};
+    // Set headers provided by global config first.
+    var configHeaders = /** @type {Object.<string>} */ (
+      spf.config.get('experimental-request-headers'));
+    if (configHeaders) {
+      for (var key in configHeaders) {
+        headers[key] = configHeaders[key];
+      }
+    }
+    // Set headers provided by options second, to allow overrides.
+    if (options.headers) {
+      for (var key in options.headers) {
+        headers[key] = options.headers[key];
+      }
+    }
     // Compare against "undefined" to allow empty referrer values in history.
     if (options.referer != undefined) {
       headers['X-SPF-Referer'] = options.referer;


### PR DESCRIPTION
In addition to the standard SPF headers (e.g. `X-SPF-Referer`), this change
allows the client to specify custom headers to send with requests.

These headers will be set globally using the `request-headers` config:
```js
spf.init({
  'request-headers': {
    'X-Custom-Header-One': 'Custom Value One',
    'X-Custom-Header-Two': 'Custom Value Two'
  }
})
```
Or, they may be set on a per-request basis for API calls using options:
```js
spf.navigate(url, {
  headers: {
    'X-Custom-Header-One': 'Custom Value One',
    'X-Custom-Header-Two': 'Custom Value Two'
  }
})
```

For now, gate the feature using the `experimental-request-headers` config
and the `experimental_headers` option.

Progress on #390
