### PR TITLE
Update timestamp generation to prefer `performance.now`

### DIFF
--- a/src/client/base.js
+++ b/src/client/base.js
@@ -111,9 +111,19 @@ spf.dispatch = function(name, opt_detail) {
  * @return {number} An integer value representing the number of milliseconds
  *     between midnight, January 1, 1970 and the current time.
  */
-spf.now = function() {
-  return (new Date()).getTime();
-};
+spf.now = (function() {
+  if (window.performance && window.performance.timing &&
+      window.performance.now) {
+    return function() {
+      var navigationStart = window.performance.timing.navigationStart;
+      var sinceNavigationStart = Math.floor(window.performance.now());
+      return navigationStart + sinceNavigationStart;
+    };
+  }
+  return function() {
+    return (new Date()).getTime();
+  };
+})();
 
 
 /**


### PR DESCRIPTION
Clock skew can occur when reporting timing values from both `Date.now` and
`performance.now` (or the `resourceTiming` API).  To ensure monotonic
timestamps, update the timestamp generation done by `spf.now` to prefer
the `performance.now` clock if it is available.

Closes #389