### PR TITLE
Don't inject application/json as javascript

### DIFF
--- a/src/client/nav/response.js
+++ b/src/client/nav/response.js
@@ -582,16 +582,30 @@ spf.nav.response.extract_ = function(frag) {
           var url = attr.match(spf.nav.response.AttributeRegEx.SRC);
           url = url ? url[1] : '';
           var async = spf.nav.response.AttributeRegEx.ASYNC.test(attr);
-          result['scripts'].push(
-              {url: url, text: text, name: name, async: async});
-          return '';
+          var type = spf.nav.response.AttributeRegEx.TYPE.exec(attr);
+          var inject = !type || spf.string.contains(type[1], '/javascript') ||
+              spf.string.contains(type[1], '/x-javascript') ||
+              spf.string.contains(type[1], '/ecmascript');
+          if (inject) {
+            result['scripts'].push(
+                {url: url, text: text, name: name, async: async});
+            return '';
+          } else {
+            return full;
+          }
         }
         // A style tag is an inline style.  Parse the name attribute.
         if (tag == 'style') {
           var name = attr.match(spf.nav.response.AttributeRegEx.NAME);
           name = name ? name[1] : '';
-          result['styles'].push({url: '', text: text, name: name});
-          return '';
+          var type = spf.nav.response.AttributeRegEx.TYPE.exec(attr);
+          var inject = !type || spf.string.contains(type[1], 'text/css');
+          if (inject) {
+            result['styles'].push({url: '', text: text, name: name});
+            return '';
+          } else {
+            return full;
+          }
         }
         // An unexpected tag was matched.  Do nothing.
         return full;
@@ -906,7 +920,8 @@ spf.nav.response.AttributeRegEx = {
   HREF: /(?:\s|^)href\s*=\s*["']?([^\s"']+)/i,
   NAME: /(?:\s|^)name\s*=\s*["']?([^\s"']+)/i,
   REL: /(?:\s|^)rel\s*=\s*["']?([^\s"']+)/i,
-  SRC: /(?:\s|^)src\s*=\s*["']?([^\s"']+)/i
+  SRC: /(?:\s|^)src\s*=\s*["']?([^\s"']+)/i,
+  TYPE: /(?:\s|^)type\s*=\s*["']([^"']+)["']/i
 };
 
 

--- a/src/client/nav/response_test.js
+++ b/src/client/nav/response_test.js
@@ -715,6 +715,59 @@ describe('spf.nav.response', function() {
       expect(result.html).toBe(expected.html);
     });
 
+    it('inject only script type javascript', function() {
+      var string = '<head>' +
+        '<script src="bar.js" name="bar" async></script>' +
+        '<script name="quatre">window.foo = 1</script>' +
+        '<script type="application/javascript">window.foo = 2</script>' +
+        '<script>window.foo = 3</script>' +
+        '<script type="text/javascript">window.foo = 4</script>' +
+        '<script type="application/ecmascript">window.foo = 5</script>' +
+        '<script type="text/ecmascript">window.foo = 6</script>' +
+        '<script type="application/x-javascript">window.foo = 7</script>' +
+        '<script type="application/json">{"foo":"bar"}</script>' +
+        '</head>';
+      var expected = {
+        scripts: [
+          {url: 'bar.js', text: '', name: 'bar', async: true},
+          {url: '', text: 'window.foo = 1', name: 'quatre', async: false},
+          {url: '', text: 'window.foo = 2', name: '', async: false},
+          {url: '', text: 'window.foo = 3', name: '', async: false},
+          {url: '', text: 'window.foo = 4', name: '', async: false},
+          {url: '', text: 'window.foo = 5', name: '', async: false},
+          {url: '', text: 'window.foo = 6', name: '', async: false},
+          {url: '', text: 'window.foo = 7', name: '', async: false}
+        ],
+        html: '<head>' +
+          '<script type="application/json">{"foo":"bar"}</script>' +
+          '</head>'
+      };
+
+      var result = spf.nav.response.extract_(string);
+      expect(result.scripts).toEqual(expected.scripts);
+      expect(result.html).toBe(expected.html);
+    });
+
+    it('inject only style type css', function() {
+      var string = '<head>' +
+        '<style name="quatre">.foo { color: red }</style>' +
+        '<style name="vingt" type="text/css">.foo { color: blue }</style>' +
+        '<style name="dix" type="text/less">.foo { color: green }</style>' +
+        '</head>';
+        var expected = {
+          styles: [
+            {url: '', text: '.foo { color: red }', name: 'quatre'},
+            {url: '', text: '.foo { color: blue }', name: 'vingt'}
+          ],
+          html: '<head>' +
+            '<style name="dix" type="text/less">.foo { color: green }</style>' +
+            '</head>'
+        };
+
+        var result = spf.nav.response.extract_(string);
+        expect(result.styles).toEqual(expected.styles);
+        expect(result.html).toBe(expected.html);
+    });
   });
 
 


### PR DESCRIPTION
We can have script tag with [json data](http://stackoverflow.com/a/7956249/1590168)
```html
<script id="data" type="application/json">{org: 10, items:["one","two"]}</script>
```
These tag is not evaluated by browers as javascript if  `type="application/json"` is present.
This PR prevent spf to inject these tags as javascript