### PR TITLE
Handle url change with spf.process & url in response

### DIFF
--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -1270,7 +1270,14 @@ spf.nav.handleLoadRedirect_ = function(isPrefetch, options, info, redirectUrl) {
  *     the `response`.
  */
 spf.nav.process = function(response, opt_callback) {
-  var url = window.location.href;
+  var url = response.url ? response.url : window.location.href;
+  var options = null;
+  if (response.url) {
+    options = new spf.nav.Info({
+      type: 'navigate'
+    });
+  }
+
   var multipart = response['type'] == 'multipart';
   var done = function(index, max, _, resp) {
     if (index == max && opt_callback) {
@@ -1282,15 +1289,14 @@ spf.nav.process = function(response, opt_callback) {
     var max = parts.length - 1;
     spf.array.each(parts, function(part, index) {
       var fn = spf.bind(done, null, index, max);
-      spf.nav.response.process(url, part, null, fn);
+      spf.nav.response.process(url, part, options, fn);
     });
   } else {
     response = /** @type {spf.SingleResponse} */ (response);
     var fn = spf.bind(done, null, 0, 0);
-    spf.nav.response.process(url, response, null, fn);
+    spf.nav.response.process(url, response, options, fn);
   }
 };
-
 
 /**
  * Dispatches the "error" event with the following custom event detail:


### PR DESCRIPTION
Hello, 

To be honest, I'm not really sure about this PR.
The method spf.process don't allow any options but I see that spf.nav.response.process will change the current url if `type: "navigate"` & `url` in response.

Here is a use case : 
- I've have a page that do a 301 redirection 
- Ajax follow the redirection and have another spf response code 200 
- I always return the url of the page processed on the response url 
- On some ajax query (form submit for example), I want to pass through spf to inject css / js / body
- The processing work well but the url is not change regardless of the url present on response.

What do you think of this PR ? 
Is it something that make sens ?

Thanks

