### PR TITLE
Full body response on onError option for spf.navigate

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -404,6 +404,11 @@ spf.EventDetail.prototype.referer;
  */
 spf.EventDetail.prototype.response;
 
+/**
+ * A complete XMLHttpRequest object; defined for "onError" events.
+ * @type {XMLHttpRequest|undefined}
+ */
+spf.EventDetail.prototype.xhr;
 
 /**
  * The target element of a click; defined for "spfclick" events.

--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -673,14 +673,15 @@ spf.nav.navigateAddHistory_ = function(url, referer, handleError) {
  * @param {spf.RequestOptions} options Request options object.
  * @param {string} url The requested URL, without the SPF identifier.
  * @param {Error} err The Error object.
+ * @param {XMLHttpRequest=} opt_xhr The XMLHttpRequest for current error
  * @private
  */
-spf.nav.handleNavigateError_ = function(options, url, err) {
+spf.nav.handleNavigateError_ = function(options, url, err, opt_xhr) {
   spf.debug.warn('navigate error', '(url=', url, ')');
   spf.state.set(spf.state.Key.NAV_REQUEST, null);
   // Ignore the error if the "error" event is canceled, but otherwise,
   // reload the page.
-  if (!spf.nav.dispatchError_(url, err, options)) {
+  if (!spf.nav.dispatchError_(url, err, options, undefined, opt_xhr)) {
     return;
   }
   spf.nav.reload(url, spf.nav.ReloadReason.ERROR, err);
@@ -1305,11 +1306,13 @@ spf.nav.process = function(response, opt_callback) {
  * @param {?spf.RequestOptions=} opt_options Optional request options object.
  * @param {boolean=} opt_noEvents Whether to skip the event and only execute the
  *     callback; for use with load and prefetch requests.
+ * @param {XMLHttpRequest=} opt_xhr The XMLHttpRequest for current error
  * @return {boolean} False if the event was canceled.
  * @private
  */
-spf.nav.dispatchError_ = function(url, err, opt_options, opt_noEvents) {
-  var detail = {'url': url, 'err': err};
+spf.nav.dispatchError_ = function(url, err, opt_options, opt_noEvents,
+                                  opt_xhr) {
+  var detail = {'url': url, 'err': err, 'xhr': opt_xhr};
   var options = opt_options || /** @type {spf.RequestOptions} */ ({});
   var fn = options[spf.nav.Callback.ERROR];
   var proceed = spf.nav.callback(fn, detail);

--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -38,7 +38,8 @@ goog.require('spf.url');
  *       argument is the requested URL; the second argument is the Error that
  *       occurred. If the type of request is "navigate", the second argument
  *       might be false if the request was canceled in response to the global
- *       "navigate-received" callback.
+ *       "navigate-received" callback. The third argument is the XMLHttpRequest
+ *       object for error
  * - onSuccess: optional callback to execute if the request succeeds.  The first
  *       argument is the requested URL; the second is the response object.  The
  *       response object will be either a complete single response object or
@@ -56,7 +57,9 @@ goog.require('spf.url');
  *   method: (string|undefined),
  *   headers: (Object.<string>|undefined),
  *   onPart: (function(string, spf.SingleResponse)|undefined),
- *   onError: (function(string, (Error|boolean))|undefined),
+ *   onError: (function(string,
+ *                   (Error|boolean),
+ *                   (XMLHttpRequest|null|undefined))|undefined),
  *   onSuccess: (function(string,
  *                   (spf.SingleResponse|spf.MultipartResponse))|undefined),
  *   postData: spf.net.xhr.PostData,
@@ -307,7 +310,7 @@ spf.nav.request.handleChunkFromXHR_ = function(url, options, timing, chunking,
     spf.debug.debug('    JSON parse failed', text);
     xhr.abort();
     if (options.onError) {
-      options.onError(url, err);
+      options.onError(url, err, xhr);
     }
     return;
   }
@@ -407,7 +410,7 @@ spf.nav.request.handleCompleteFromXHR_ = function(url, options, timing,
     if (!xhr.response) {
       spf.debug.debug('    JSON parse failed');
       if (options.onError) {
-        options.onError(url, new Error('JSON response parsing failed'));
+        options.onError(url, new Error('JSON response parsing failed'), xhr);
       }
       return;
     }
@@ -425,7 +428,7 @@ spf.nav.request.handleCompleteFromXHR_ = function(url, options, timing,
     } catch (err) {
       spf.debug.debug('    JSON parse failed');
       if (options.onError) {
-        options.onError(url, err);
+        options.onError(url, err, xhr);
       }
       return;
     }


### PR DESCRIPTION
For now, we just received on simple detail.err string for failed navigate on option onError, I've added a detail.xhr with the full XMLHttpRequest in order to have more detail and responseText for debuging or displaying 