### PR TITLE
Update Bower file to add/remove recommended/deprecated fields

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,14 +1,18 @@
 {
   "name": "spf",
-  "version": "2.3.2",
   "description": "A lightweight JS framework for fast navigation and page updates from YouTube",
+  "main": "dist/spf.js",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/youtube/spfjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/youtube/spfjs.git"
   },
-  "main": "dist/spf.js",
   "ignore": [
     "**/.*",
     "bower_components",


### PR DESCRIPTION
This change updates `bower.json` to remove the following
deprecated fields:
- `version` (Ignored by Bower in favor of git tags)

And, this change adds the following recommended fields:
- `moduleType` (The type of module defined in the `main` file)

Progress on #406