### PR TITLE
Release custom headers for requests

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -238,7 +238,7 @@ spf.RequestOptions;
  * Optional map of headers to send with the request.
  * @type {Object.<string>|undefined}
  */
-spf.RequestOptions.prototype.experimental_headers;
+spf.RequestOptions.prototype.headers;
 
 
 /**

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -273,7 +273,7 @@ spf.MultipartResponse;
 
 /**
  * Type definition for the configuration options for requesting a URL.
- * - experimental_headers: optional map of headers to send with the request.
+ * - headers: optional map of headers to send with the request.
  * - method: optional method with which to send the request; defaults to "GET".
  * - onDone: optional callback when either repsonse is done being processed.
  * - onError: optional callback if an error occurs.
@@ -287,7 +287,7 @@ spf.MultipartResponse;
  *       is set to "POST".
  *
  * @typedef {{
- *   experimental_headers: (Object.<string>|undefined),
+ *   headers: (Object.<string>|undefined),
  *   method: (string|undefined),
  *   onDone: (function(spf.EventDetail)|undefined),
  *   onError: (function(spf.EventDetail)|undefined),

--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -571,7 +571,7 @@ spf.nav.navigateSendRequest_ = function(url, options, info) {
 
   var xhr = spf.nav.request.send(url, {
     method: options['method'],
-    headers: options['experimental_headers'],
+    headers: options['headers'],
     onPart: handlePart,
     onError: handleError,
     onSuccess: handleSuccess,
@@ -978,7 +978,7 @@ spf.nav.load_ = function(url, options, info) {
 
   spf.nav.request.send(url, {
     method: options['method'],
-    headers: options['experimental_headers'],
+    headers: options['headers'],
     onPart: handlePart,
     onError: handleError,
     onSuccess: handleSuccess,
@@ -1036,7 +1036,7 @@ spf.nav.prefetch_ = function(url, options, info) {
 
   var xhr = spf.nav.request.send(url, {
     method: options['method'],
-    headers: options['experimental_headers'],
+    headers: options['headers'],
     onPart: handlePart,
     onError: handleError,
     onSuccess: handleSuccess,

--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -126,7 +126,7 @@ spf.nav.request.send = function(url, opt_options) {
     var headers = {};
     // Set headers provided by global config first.
     var configHeaders = /** @type {Object.<string>} */ (
-      spf.config.get('experimental-request-headers'));
+      spf.config.get('request-headers'));
     if (configHeaders) {
       for (var key in configHeaders) {
         var value = configHeaders[key];


### PR DESCRIPTION
This change removes the "experimental" gate to allow the client
to specify custom headers to send with requests.

The headers may be set globally using the `request-headers` config:
```js
spf.init({
  'request-headers': {
    'X-Custom-Header-One': 'Custom Value One',
    'X-Custom-Header-Two': 'Custom Value Two'
  }
})
```
Or, they may be set on a per-request basis for API calls using
the `headers` option:
```js
spf.navigate(url, {
  headers: {
    'X-Custom-Header-One': 'Custom Value One',
    'X-Custom-Header-Two': 'Custom Value Two'
  }
})
```

Closes #390