### PR TITLE
Don't set XHR content-type if postData is FormData.

### DIFF
--- a/src/client/net/xhr.js
+++ b/src/client/net/xhr.js
@@ -153,7 +153,7 @@ spf.net.xhr.send = function(method, url, data, opt_options) {
 
   // For POST, default to `Content-Type: application/x-www-form-urlencoded`
   // unless a custom header was given.
-  var isFormData = (data instanceof FormData);
+  var isFormData = ('FormData' in window && data instanceof FormData);
   var addContentTypeFormUrlEncoded = (method == 'POST' && !isFormData);
   if (options.headers) {
     for (var key in options.headers) {

--- a/src/client/net/xhr.js
+++ b/src/client/net/xhr.js
@@ -153,7 +153,8 @@ spf.net.xhr.send = function(method, url, data, opt_options) {
 
   // For POST, default to `Content-Type: application/x-www-form-urlencoded`
   // unless a custom header was given.
-  var addContentTypeFormUrlEncoded = (method == 'POST' && !(data instanceof FormData));
+  var isFormData = (data instanceof FormData);
+  var addContentTypeFormUrlEncoded = (method == 'POST' && !isFormData);
   if (options.headers) {
     for (var key in options.headers) {
       xhr.setRequestHeader(key, options.headers[key]);

--- a/src/client/net/xhr.js
+++ b/src/client/net/xhr.js
@@ -153,7 +153,7 @@ spf.net.xhr.send = function(method, url, data, opt_options) {
 
   // For POST, default to `Content-Type: application/x-www-form-urlencoded`
   // unless a custom header was given.
-  var addContentTypeFormUrlEncoded = (method == 'POST');
+  var addContentTypeFormUrlEncoded = (method == 'POST' && !(data instanceof FormData));
   if (options.headers) {
     for (var key in options.headers) {
       xhr.setRequestHeader(key, options.headers[key]);


### PR DESCRIPTION
Browser will automatically set mime type and boundary.