### PR TITLE
Allow setting withCredentials in spf xhr options

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -326,6 +326,13 @@ spf.RequestOptions.prototype.postData;
 
 
 /**
+ * Optional flag to configure the XHR to send withCredentials or not.
+ * @type {boolean|undefined}
+ */
+spf.RequestOptions.prototype.withCredentials;
+
+
+/**
  * Definition of CustomEvents dispatched by SPF.
  * @interface
  * @extends {CustomEvent}

--- a/src/client/base.js
+++ b/src/client/base.js
@@ -285,6 +285,7 @@ spf.MultipartResponse;
  * - onRequest: optional callback when a request will be made.
  * - postData: optional data to send with a request.  Only used if the method
  *       is set to "POST".
+ * - withCredentials: optional flag to send credentials if true.
  *
  * @typedef {{
  *   headers: (Object.<string>|undefined),
@@ -295,7 +296,8 @@ spf.MultipartResponse;
  *   onPartProcess: (function(spf.EventDetail)|undefined),
  *   onProcess: (function(spf.EventDetail)|undefined),
  *   onRequest: (function(spf.EventDetail)|undefined),
- *   postData: (ArrayBuffer|Blob|Document|FormData|null|string|undefined)
+ *   postData: (ArrayBuffer|Blob|Document|FormData|null|string|undefined),
+ *   withCredentials: (boolean|undefined)
  * }}
  */
 spf.RequestOptions;

--- a/src/client/nav/nav.js
+++ b/src/client/nav/nav.js
@@ -983,7 +983,8 @@ spf.nav.load_ = function(url, options, info) {
     onError: handleError,
     onSuccess: handleSuccess,
     postData: options['postData'],
-    type: info.type
+    type: info.type,
+    withCredentials: options['withCredentials']
   });
 };
 

--- a/src/client/nav/request.js
+++ b/src/client/nav/request.js
@@ -52,6 +52,7 @@ goog.require('spf.url');
  *       alter the URL identifier and XHR header and used to determine whether
  *       the global "navigation received" callback is executed; defaults to
  *       "request".
+ * - withCredentials: optional flag to send credentials if true.
  *
  * @typedef {{
  *   method: (string|undefined),
@@ -65,7 +66,8 @@ goog.require('spf.url');
  *   postData: spf.net.xhr.PostData,
  *   current: (string|null|undefined),
  *   referer: (string|null|undefined),
- *   type: (string|undefined)
+ *   type: (string|undefined),
+ *   withCredentials: (boolean|undefined)
  * }}
  */
 spf.nav.request.Options;
@@ -194,6 +196,11 @@ spf.nav.request.send = function(url, opt_options) {
       onDone: handleComplete,
       onTimeout: handleComplete
     };
+
+    if (options.withCredentials) {
+      xhrOpts.withCredentials = options.withCredentials;
+    }
+
     // As an advanced option, allow XHR requests to enforce JSON responses.
     // This can make response parsing more efficient by reducing contention on
     // the main thread (especially for very large responses), but as a

--- a/src/client/net/xhr.js
+++ b/src/client/net/xhr.js
@@ -30,6 +30,7 @@ goog.require('spf');
  * - responseType: type to create from the XHR response.
  * - timeoutMs: number of milliseconds after which the request will be timed
  *      out by the client. Default is to allow the browser to handle timeouts.
+ * - withCredentials: optional flag to send credentials if true.
  *
  * @typedef {{
  *   headers: (Object.<string>|undefined),
@@ -38,7 +39,8 @@ goog.require('spf');
  *   onHeaders: (function(XMLHttpRequest)|undefined),
  *   onTimeout: (function(XMLHttpRequest)|undefined),
  *   responseType: (string|undefined),
- *   timeoutMs: (number|undefined)
+ *   timeoutMs: (number|undefined),
+ *   withCredentials: (boolean|undefined)
  * }}
  */
 spf.net.xhr.Options;
@@ -149,6 +151,10 @@ spf.net.xhr.send = function(method, url, data, opt_options) {
   // NOTE: This removes the ability to handle chunked responses on the fly.
   if ('responseType' in xhr && options.responseType == 'json') {
     xhr.responseType = 'json';
+  }
+
+  if (options.withCredentials) {
+    xhr.withCredentials = options.withCredentials;
   }
 
   // For POST, default to `Content-Type: application/x-www-form-urlencoded`


### PR DESCRIPTION
This allows SPF to be used with CORS + Cookies.