### PR TITLE
spf.config without init

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -30,6 +30,16 @@ spf.init = function(opt_config) {};
 
 
 /**
+ * Set global configuration without initialization.
+ *
+ * @param {string} key The configuration key.
+ * @param {string} value The configuration value.
+ * @return {spf.config.Value} The configuration value.
+ */
+spf.config = function(key, value) {};
+
+
+/**
  * Disposes SPF.
  */
 spf.dispose = function() {};

--- a/src/client/config.js
+++ b/src/client/config.js
@@ -55,7 +55,13 @@ spf.config.init = function(opt_config) {
   var config = opt_config || {};
   // Set primary configs; each has a default.
   for (var key in spf.config.defaults) {
-    var value = (key in config) ? config[key] : spf.config.defaults[key];
+    // config is already define with spf.config, keep define values
+    if (spf.config.has(key)) {
+      var value = (key in config) ? config[key] : spf.config.get(key);
+    } else {
+      var value = (key in config) ? config[key] : spf.config.defaults[key];
+    }
+
     spf.config.set(key, value);
   }
   // Set advanced and experimental configs; none have defaults.

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -40,6 +40,18 @@ spf.main.init = function(opt_config) {
 
 
 /**
+ * Set global configuration without initialization.
+ *
+ * @param {string} key The configuration key.
+ * @param {string} value The configuration value.
+ * @return {spf.config.Value} The configuration value.
+ */
+spf.main.config = function(key, value) {
+  return spf.config.set(key, value);
+};
+
+
+/**
  * Checks to see if SPF can be initialized.
  *
  * @return {boolean}
@@ -101,6 +113,7 @@ spf.main.discover_();
 /** @private {!Object} */
 spf.main.api_ = {
   'init': spf.main.init,
+  'config': spf.main.config,
   'dispose': spf.main.dispose,
   'navigate': spf.nav.navigate,
   'load': spf.nav.load,


### PR DESCRIPTION
I need to set a configuration variable with init spf.
I only use the spf.process method without using navigate (because I need to handle fragments myself).
Calling spf.init will auto enable spf.history manager & broke mine. 

I add a spf.config method that can set a configuration variable without init spf.
