### PR TITLE
Improve test reliability on platforms with clock skew

### DIFF
--- a/src/client/cache/cache_test.js
+++ b/src/client/cache/cache_test.js
@@ -21,7 +21,7 @@ describe('spf.cache', function() {
     time = { advance: 0 };
     spf.__now = spf.now;
     spf.now = function() {
-      return (+new Date()) + time.advance;
+      return (new Date()).getTime() + time.advance;
     };
     // Reset.
     storage = spf.cache.storage_();

--- a/src/client/history/history_test.js
+++ b/src/client/history/history_test.js
@@ -50,7 +50,7 @@ describe('spf.history', function() {
     time = { advance: 0 };
     spf.__now = spf.now;
     spf.now = function() {
-      return (+new Date()) + time.advance;
+      return (new Date()).getTime() + time.advance;
     };
     // Init.
     callbacks = {

--- a/src/client/nav/request_test.js
+++ b/src/client/nav/request_test.js
@@ -920,7 +920,7 @@ describe('spf.nav.request', function() {
     it('regular: single, navigation timing', function() {
       var url = '/page';
       var text = '{}';
-      var startTime = new Date().getTime() - 1;
+      var startTime = spf.now() - 1;
       var fake = createFakeRegularXHR(text);
       spf.net.xhr.get = jasmine.createSpy('xhr.get').and.callFake(fake);
 
@@ -938,7 +938,7 @@ describe('spf.nav.request', function() {
     it('cached: single, navigation timing', function() {
       var url = '/page';
       var res = {'foo': 'FOO', 'bar': 'BAR'};
-      var startTime = new Date().getTime() - 1;
+      var startTime = spf.now() - 1;
 
       var cacheKey = 'prefetch ' + spf.url.absolute(url);
       var cacheObject = {


### PR DESCRIPTION
On platforms with significant clock skew between `performance.now()`
and `(new Date()).getTime()`, tests that do not use `spf.now()` are
unreliable.  Fix this by using `spf.now()` in tests.

Also, standardize on `(new Date()).getTime()` instead of
`(+new Date())`, which was only being used in tests.