### PR TITLE
Suppress "non-existent property" warnings in spf.url

### DIFF
--- a/src/client/url/url.js
+++ b/src/client/url/url.js
@@ -7,6 +7,7 @@
  * @fileoverview URL manipulation functions.
  *
  * @author nicksay@google.com (Alex Nicksay)
+ * @suppress {missingProperties}
  */
 
 goog.provide('spf.url');


### PR DESCRIPTION
Tighter property checking in JsCompiler is warning about the `username`
and `password` property access on `a` elements.  Temporarily suppress
these warnings until the default externs can be fixed or the property
accesses are removed.