### PR TITLE
Feature/history

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -489,6 +489,52 @@ spf.cache.clear = function() {};
 
 
 /**
+ * Namespace for history handling functions.
+ * @namespace
+ */
+spf.history = {};
+
+
+/**
+ * Add a history entry.
+ *
+ * @param {?string=} opt_url The URL associated with this entry to display in
+ *     the browser.  This can be either a relative or an absolute URL, and if
+ *     omitted, the current browser URL will be used.
+ * @param {Object=} opt_state The state object associated with this history
+ *     entry.  When the user returns to this entry, the "state" property of the
+ *     event will contain a copy of this object.
+ * @param {boolean=} opt_doCallback Whether to do the history event callback.
+ * @throws {Error} If the state object is too large. For example, Firefox will
+ *     pass the object to JSON.stringify and impose a 640k character limit.
+ * @throws {Error} If the URL is not in the same domain, a SECURITY_ERR
+ *     (code == 18) is thrown.
+ * @throws {Error} If window.history.pushState is not a function.
+ */
+spf.history.add = function(opt_url, opt_state, opt_doCallback) {};
+
+
+/**
+ * Replace the current history entry, merging any newly provided state values
+ * with existing ones.
+ *
+ * @param {?string=} opt_url The URL associated with this entry to display in
+ *     the browser.  This can be either a relative or an absolute URL, and if
+ *     omitted, the current browser URL will be used.
+ * @param {Object=} opt_state The state object associated with this history
+ *     entry.  When the user returns to this entry, the "state" property of the
+ *     event will contain a copy of this object.
+ * @param {boolean=} opt_doCallback Whether to do the history event callback.
+ * @throws {Error} If the state object is too large. For example, Firefox will
+ *     pass the object to JSON.stringify and impose a 640k character limit.
+ * @throws {Error} If the URL is not in the same domain, a SECURITY_ERR
+ *     (code == 18) is thrown.
+ * @throws {Error} If window.history.replaceState is not a function.
+ */
+spf.history.replace = function(opt_url, opt_state, opt_doCallback) {};
+
+
+/**
  * Namespace for script-loading functions.
  * @namespace
  */

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -116,6 +116,13 @@ spf.main.extra_ = {
     // * Clear all entries.
     'clear': spf.cache.clear
   },
+  'history': {
+    // History API.
+    // * Add a history entry.
+    'add': spf.history.add,
+    // * Replace the current history entry
+    'replace': spf.history.replace
+  },
   'script': {
     // The bootloader API.
     // * Load scripts.


### PR DESCRIPTION
Just exposing the history api help a lot on my current project.
I was able to use spf in order to :
* do simple navigation (the main goal of spf) 
* submit form with spf
* but mostly, display spf request in a modal and with an url (#/url)
  * forward and backup open close the modal 
  * I can have multiple modal on one page (#/url1#/url2)

In my previous PR #419, I was just using the spf.process method and I have to deal with the history manager. This lead to a lot of bug and since spf handle it nicely and I try another way but I need the have access to history api.

Let me know if you think it can be useful for other people