### PR TITLE
Option to use main window window.history

### DIFF
--- a/src/client/config.js
+++ b/src/client/config.js
@@ -41,7 +41,8 @@ spf.config.defaults = {
   'navigate-lifetime': 24 * 60 * 60 * 1000,  // 1 day session lifetime (ms).
   'reload-identifier': null,  // Always a param, no '?' needed.
   'request-timeout': 0,  // No request timeout.
-  'url-identifier': '?spf=__type__'
+  'url-identifier': '?spf=__type__',
+  'use-iframe': true
 };
 
 

--- a/src/client/history/history.js
+++ b/src/client/history/history.js
@@ -265,7 +265,7 @@ spf.history.doPushState_ = function(data, title, opt_url) {
   // This check makes sure that pushState is a function when called to
   // avoid js errors and a state where the back arrow stops working.
   var iframe = spf.history.getIframe();
-  var pushState = iframe.contentWindow.history.pushState;
+  var pushState = iframe.history.pushState;
   if (typeof pushState == 'function') {
     pushState.call(window.history, data, title, opt_url);
   } else {
@@ -282,7 +282,7 @@ spf.history.doPushState_ = function(data, title, opt_url) {
  */
 spf.history.doReplaceState_ = function(data, title, opt_url) {
   var iframe = spf.history.getIframe();
-  var replaceState = iframe.contentWindow.history.replaceState;
+  var replaceState = iframe.history.replaceState;
   if (typeof replaceState == 'function') {
     replaceState.call(window.history, data, title, opt_url);
   } else {
@@ -292,12 +292,21 @@ spf.history.doReplaceState_ = function(data, title, opt_url) {
 
 
 /**
- * @return {!HTMLIFrameElement} The history iframe.
+ * @return {!Window} The history iframe.
  */
 spf.history.getIframe = function() {
-  var frame = document.getElementById('history-iframe');
-  if (!frame) {
-    frame = spf.dom.createIframe('history-iframe');
+  var frame = null;
+  if (spf.config.get('use-iframe')) {
+    frame = document.getElementById('history-iframe');
+
+    if (!frame) {
+      frame = spf.dom.createIframe('history-iframe');
+    }
+
+    frame = frame.contentWindow;
+  } else {
+    frame = window
   }
-  return /** @type {!HTMLIFrameElement} */ (frame);
+
+  return /** @type {!Window} */ (frame);
 };

--- a/src/client/main.js
+++ b/src/client/main.js
@@ -47,7 +47,7 @@ spf.main.init = function(opt_config) {
  */
 spf.main.canInit_ = function() {
   return !!(typeof window.history.pushState == 'function' ||
-      spf.history.getIframe().contentWindow.history.pushState);
+      spf.history.getIframe().history.pushState);
 };
 
 


### PR DESCRIPTION
I've added an option to use window.history instead of iframe history.
This is needed by google tag manager & facebook pixel, they overload some method window.history method in order to track new change.
Without this options, these pixel are unusable with spf application

To be honest, I don't understand the reason of using an iframe :smile: 