### PR TITLE
Suppress strictMissingDeps in SPFJS.

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -13,8 +13,7 @@
 /**
  * The top-level SPF namespace.
  * @namespace
- * @suppress {duplicate}
- * @noalias
+ * @suppress {duplicate,strictMissingProperties}
  */
 var spf = {};
 


### PR DESCRIPTION
This is safe to ignore in SPF code.