### PR TITLE
Add a "assume-all-json-requests-chunked" configuration option.

### DIFF
--- a/src/client/net/xhr.js
+++ b/src/client/net/xhr.js
@@ -12,6 +12,7 @@
 goog.provide('spf.net.xhr');
 
 goog.require('spf');
+goog.require('spf.config');
 
 
 /**
@@ -202,6 +203,9 @@ spf.net.xhr.send = function(method, url, data, opt_options) {
 spf.net.xhr.isChunked_ = function(xhr) {
   if (xhr.responseType == 'json') {
     return false;
+  }
+  if (spf.config.get('assume-all-json-requests-chunked')){
+    return true;
   }
   // Determine whether to process chunks as they arrive.
   // This is only possible with chunked transfer encoding.


### PR DESCRIPTION
Add a configuration option used to explicitly assume all json requests will be chunked. This can be used as an alternative to SPDY detection (based on the primary document load state).