### PR TITLE
Add configuration to consider all requests chunked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
   - 0.10
+env:
+  - SKIP_JAVA_VERSION_CHECK=true
 install:
   - npm install
 before_script:

--- a/bin/calcdeps.js
+++ b/bin/calcdeps.js
@@ -349,7 +349,7 @@ deps.build = function(infos) {
     // Add each provided namespace from that file to the map.
     info.provides.forEach(function(ns) {
       if (ns in hash) {
-        $.util.error($.util.format(
+        console.error($.util.format(
             'Duplicate provide for "%s" in %s and %s.',
             ns, info.path, hash[ns].path));
         process.exit(1);
@@ -377,7 +377,7 @@ deps.build = function(infos) {
 deps.resolve = function(info, hash, ordered, seen) {
   info.requires.forEach(function(ns) {
     if (!(ns in hash)) {
-      $.util.error($.util.format(
+      console.error($.util.format(
           'Missing provide for "%s" required by %s.',
           ns, info.path));
       process.exit(1);
@@ -409,13 +409,13 @@ deps.order = function(hash, inputs) {
     if (tests.isNS(input)) {
       var ns = NAMESPACE_REGEX.exec(input)[1];
       if (!(ns in hash)) {
-        $.util.error($.util.format('Missing input namespace "%s".', ns));
+        console.error($.util.format('Missing input namespace "%s".', ns));
         process.exit(1);
       }
       info = hash[ns];
     } else {
       if (!(input in hash)) {
-        $.util.error($.util.format('Missing input file "%s".', input));
+        console.error($.util.format('Missing input file "%s".', input));
         process.exit(1);
       }
       info = hash[input];
@@ -532,7 +532,7 @@ function main(opts, args) {
   } else if (opts.mode == 'concat') {
     output = infos.map(function(info) { return info.content; }).join('\n');
   } else {
-    $.util.error('Unknown output mode');
+    console.error('Unknown output mode');
     process.exit(1);
   }
 

--- a/bin/configure.js
+++ b/bin/configure.js
@@ -74,11 +74,14 @@ function requirements() {
   var required = $.semver('1.7.0');
   $.childProcess.exec('java -version', function(error, stdout, stderr) {
     if (error || !stderr) {
-      $.util.error([
-            'Unable to get java version.',
-            'Please install java before building.',
-          ].join('\n'));
+      console.error([
+        'Unable to get java version.',
+        'Please install java before building.',
+      ].join('\n'));
       process.exit(1);
+    }
+    if (process.env.SKIP_JAVA_VERSION_CHECK) {
+      return;
     }
     var version;
     var installed;
@@ -88,10 +91,12 @@ function requirements() {
       installed = $.semver.parse(version.replace('_', '-'));
     } catch (ex) {}
     if (!installed || installed < required) {
-      $.util.error($.util.format([
+      console.error($.util.format(
+          [
             'Installed java version "%s" is less than the required "%s".',
             'Please upgrade java before building.'
-          ].join('\n'), installed, required));
+          ].join('\n'),
+          installed, required));
       process.exit(1);
     }
   });

--- a/src/client/net/xhr.js
+++ b/src/client/net/xhr.js
@@ -12,6 +12,7 @@
 goog.provide('spf.net.xhr');
 
 goog.require('spf');
+goog.require('spf.config');
 
 
 /**
@@ -202,6 +203,9 @@ spf.net.xhr.send = function(method, url, data, opt_options) {
 spf.net.xhr.isChunked_ = function(xhr) {
   if (xhr.responseType == 'json') {
     return false;
+  }
+  if (spf.config.get('assume-all-json-requests-chunked')) {
+    return true;
   }
   // Determine whether to process chunks as they arrive.
   // This is only possible with chunked transfer encoding.


### PR DESCRIPTION
Add a configuration option used to explicitly assume all json requests will be chunked. This can be used as an alternative to SPDY detection (based on the primary document load state).