### PR TITLE
Added support for importing via webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "bugs": {
     "url": "https://github.com/youtube/spfjs/issues"
   },
+  "main": "dist/spf.js",
+  "module": "dist/spf.js",
   "scripts": {
     "prepublish": "bower install && bin/configure.js",
     "build": "ninja",


### PR DESCRIPTION
Currently it's not possible to import  the library within build systems like WebPack.

For example, at the moment you can't do this:

```javascript
import { spf } from 'spf';
```

It will throw an unresolvable package error. It can be fixed just by adding just these two lines in the **package.json**

```javascript
  "main": "dist/spf.js",
  "module": "dist/spf.js",
```

Now, WebPack will be able to resolve the package when imported. Yes, you can always define custom resolvers in WebPack, but it's still pretty convenient to have by default.
